### PR TITLE
feat: add secondary indexes + querying tx by hash

### DIFF
--- a/internal/mock/storage.go
+++ b/internal/mock/storage.go
@@ -13,6 +13,7 @@ type Storage struct {
 	GetWriteBatchFn        func() storage.Batch
 	GetBlockFn             func(uint64) (*types.Block, error)
 	GetTxFn                func(uint64, uint32) (*types.TxResult, error)
+	GetTxByHashFn          func(string) (*types.TxResult, error)
 }
 
 func (m *Storage) GetLatestHeight() (uint64, error) {
@@ -36,6 +37,14 @@ func (m *Storage) GetBlock(blockNum uint64) (*types.Block, error) {
 func (m *Storage) GetTx(blockNum uint64, index uint32) (*types.TxResult, error) {
 	if m.GetTxFn != nil {
 		return m.GetTxFn(blockNum, index)
+	}
+
+	panic("not implemented")
+}
+
+func (m *Storage) GetTxByHash(txHash string) (*types.TxResult, error) {
+	if m.GetTxByHashFn != nil {
+		return m.GetTxByHashFn(txHash)
 	}
 
 	panic("not implemented")

--- a/serve/graph/model/models_gen.go
+++ b/serve/graph/model/models_gen.go
@@ -45,4 +45,6 @@ type TransactionFilter struct {
 	FromGasUsed *int `json:"from_gas_used,omitempty"`
 	// Maximum `gas_used` value for filtering Transactions, exclusive. Refines selection based on the computational effort actually consumed.
 	ToGasUsed *int `json:"to_gas_used,omitempty"`
+	// Hash from Transaction content in base64 encoding. If this filter is used, any other filter will be ignored.
+	Hash *string `json:"hash,omitempty"`
 }

--- a/serve/graph/model/transaction.go
+++ b/serve/graph/model/transaction.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
@@ -20,6 +21,10 @@ func (t *Transaction) ID() string {
 
 func (t *Transaction) Index() int {
 	return int(t.t.Index)
+}
+
+func (t *Transaction) Hash() string {
+	return base64.StdEncoding.EncodeToString(t.t.Tx.Hash())
 }
 
 func (t *Transaction) BlockHeight() int {

--- a/serve/graph/schema.graphql
+++ b/serve/graph/schema.graphql
@@ -44,6 +44,11 @@ type Transaction {
   index: Int!
 
   """
+  Hash from Transaction content in base64 encoding.
+  """
+  hash: String!
+
+  """
   The height of the Block in which this Transaction is included. Links the Transaction to its containing Block.
   """
   block_height: Int!
@@ -134,6 +139,12 @@ input TransactionFilter {
   Maximum `gas_used` value for filtering Transactions, exclusive. Refines selection based on the computational effort actually consumed.
   """
   to_gas_used: Int
+
+  """
+  Hash from Transaction content in base64 encoding. If this filter is used, any other filter will be ignored.
+  """
+  hash: String
+
 }
 
 """

--- a/serve/graph/schema.resolvers.go
+++ b/serve/graph/schema.resolvers.go
@@ -9,14 +9,22 @@ import (
 	"math"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-
 	"github.com/gnolang/tx-indexer/serve/graph/model"
 	"github.com/gnolang/tx-indexer/types"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Transactions is the resolver for the transactions field.
 func (r *queryResolver) Transactions(ctx context.Context, filter model.TransactionFilter) ([]*model.Transaction, error) {
+	if filter.Hash != nil {
+		tx, err := r.store.GetTxByHash(*filter.Hash)
+		if err != nil {
+			return nil, gqlerror.Wrap(err)
+		}
+
+		return []*model.Transaction{model.NewTransaction(tx)}, nil
+	}
+
 	it, err := r.
 		store.
 		TxIterator(

--- a/serve/handlers/tx/mocks_test.go
+++ b/serve/handlers/tx/mocks_test.go
@@ -4,13 +4,24 @@ import "github.com/gnolang/gno/tm2/pkg/bft/types"
 
 type getTxDelegate func(uint64, uint32) (*types.TxResult, error)
 
+type getTxHashDelegate func(string) (*types.TxResult, error)
+
 type mockStorage struct {
-	getTxFn getTxDelegate
+	getTxFn     getTxDelegate
+	getTxHashFn getTxHashDelegate
 }
 
 func (m *mockStorage) GetTx(bn uint64, ti uint32) (*types.TxResult, error) {
 	if m.getTxFn != nil {
 		return m.getTxFn(bn, ti)
+	}
+
+	return nil, nil
+}
+
+func (m *mockStorage) GetTxByHash(h string) (*types.TxResult, error) {
+	if m.getTxHashFn != nil {
+		return m.getTxHashFn(h)
 	}
 
 	return nil, nil

--- a/serve/handlers/tx/types.go
+++ b/serve/handlers/tx/types.go
@@ -5,4 +5,7 @@ import "github.com/gnolang/gno/tm2/pkg/bft/types"
 type Storage interface {
 	// GetTx returns specified tx from permanent storage
 	GetTx(uint64, uint32) (*types.TxResult, error)
+
+	// GetTxByHash fetches the tx using the transaction hash
+	GetTxByHash(txHash string) (*types.TxResult, error)
 }

--- a/serve/jsonrpc.go
+++ b/serve/jsonrpc.go
@@ -120,6 +120,11 @@ func (j *JSONRPC) RegisterTxEndpoints(db tx.Storage) {
 		"getTxResult",
 		txHandler.GetTxHandler,
 	)
+
+	j.RegisterHandler(
+		"getTxResultByHash",
+		txHandler.GetTxByHashHandler,
+	)
 }
 
 // RegisterBlockEndpoints registers the block endpoints

--- a/storage/types.go
+++ b/storage/types.go
@@ -25,6 +25,9 @@ type Reader interface {
 	// GetTx fetches the tx using the block height and the transaction index
 	GetTx(blockNum uint64, index uint32) (*types.TxResult, error)
 
+	// GetTxByHash fetches the tx using the transaction hash
+	GetTxByHash(txHash string) (*types.TxResult, error)
+
 	// BlockIterator iterates over Blocks, limiting the results to be between the provided block numbers
 	BlockIterator(fromBlockNum, toBlockNum uint64) (Iterator[*types.Block], error)
 


### PR DESCRIPTION
Sadly, I had to encode hashes using base64 instead of base16 to keep
compatibility with other places where we are showing the hash as base64
to the user...

- BREAKING CHANGE: The indexer database has to be re-fetched to apply the secondary index by hash.

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>