### PR TITLE
chore: change default listening port from 8545 to 8546

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Starts the indexer service, which includes the fetcher and JSON-RPC server
 
 FLAGS
   -db-path indexer-db             the absolute path for the indexer DB (embedded)
-  -listen-address 0.0.0.0:8545    the IP:PORT URL for the indexer JSON-RPC server
+  -listen-address 0.0.0.0:8546    the IP:PORT URL for the indexer JSON-RPC server
   -log-level info                 the log level for the CLI output
   -max-chunk-size 100             the range for fetching blockchain data by a single worker
   -max-slots 100                  the amount of slots (workers) the fetcher employs

--- a/serve/server.go
+++ b/serve/server.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	DefaultListenAddress = "0.0.0.0:8545"
+	DefaultListenAddress = "0.0.0.0:8546"
 )
 
 type HTTPServer struct {


### PR DESCRIPTION
The Gno faucet already used port 8545 ([see here](https://github.com/gnolang/faucet/blob/f72cfa2c741758472ce5cf2a2b1087adde0afaab/config/config.go#L12)). So I propose to change the default tx-indexer listening port to 8546 to avoid conflicts when faucet and tx-indexer are running in the same machine.