### PR TITLE
fix: missing first elem in graphql tx iterator

### DIFF
--- a/storage/pebble.go
+++ b/storage/pebble.go
@@ -261,17 +261,12 @@ type PebbleTxIter struct {
 func (pi *PebbleTxIter) Next() bool {
 	for {
 		if !pi.init {
-			pi.init = true
 			if !pi.i.First() {
 				return false
 			}
-		}
 
-		if !pi.i.Valid() {
-			return false
-		}
-
-		if !pi.i.Next() {
+			pi.init = true
+		} else if !pi.i.Next() {
 			return false
 		}
 

--- a/storage/pebble_test.go
+++ b/storage/pebble_test.go
@@ -145,7 +145,7 @@ func TestStorageIters(t *testing.T) {
 		txCount++
 	}
 
-	require.Equal(t, 2, txCount)
+	require.Equal(t, 3, txCount)
 
 	defer require.NoError(t, it.Close())
 


### PR DESCRIPTION
The graphql transactions query is missing the first element

 On first step, the transaction iterator is yielding twice and only the second value is processed

Portal Loop today before fix:
<img width="851" alt="Screenshot 2024-04-15 at 01 17 18" src="https://github.com/gnolang/tx-indexer/assets/7917064/585d1d05-5e63-483f-9c79-415629fefaf6">

Portal loop today after fix:
<img width="854" alt="Screenshot 2024-04-15 at 01 16 15" src="https://github.com/gnolang/tx-indexer/assets/7917064/02169f75-10dc-4f85-95a2-299e2089d7c1">
