### PR TITLE
feat: Add events to the transaction model in GraphQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/99designs/gqlgen v0.17.45
 	github.com/cockroachdb/pebble v1.1.0
-	github.com/gnolang/gno v0.0.0-20240429120125-3832b1312d7d
+	github.com/gnolang/gno v0.0.0-20240502173657-6482c18da2c7
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/httprate v0.9.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/gnolang/gno v0.0.0-20240429120125-3832b1312d7d h1:vD4URFbnv8UL/NG8fX5pjVPRyQ1tvCtqTzU5I996EtA=
-github.com/gnolang/gno v0.0.0-20240429120125-3832b1312d7d/go.mod h1:vbm5sS6KZj2rkwJ9C6AtdpPZB7aZDhfZ3lJUC+qa/to=
+github.com/gnolang/gno v0.0.0-20240502173657-6482c18da2c7 h1:G9dv/bhGj4aWbar1nCD4ckjdb/NrGwqNK5sWaFi+jZA=
+github.com/gnolang/gno v0.0.0-20240502173657-6482c18da2c7/go.mod h1:vbm5sS6KZj2rkwJ9C6AtdpPZB7aZDhfZ3lJUC+qa/to=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216/go.mod h1:xJhtEL7ahjM1WJipt89gel8tHzfIl/LyMY+lCYh38d8=
 github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=

--- a/serve/graph/generated.go
+++ b/serve/graph/generated.go
@@ -118,6 +118,18 @@ type ComplexityRoot struct {
 		Success     func(childComplexity int) int
 	}
 
+	TransactionEvent struct {
+		Attrs   func(childComplexity int) int
+		Func    func(childComplexity int) int
+		PkgPath func(childComplexity int) int
+		Type    func(childComplexity int) int
+	}
+
+	TransactionEventAttribute struct {
+		Key   func(childComplexity int) int
+		Value func(childComplexity int) int
+	}
+
 	TransactionMessage struct {
 		Route   func(childComplexity int) int
 		TypeURL func(childComplexity int) int
@@ -125,10 +137,11 @@ type ComplexityRoot struct {
 	}
 
 	TransactionResponse struct {
-		Data  func(childComplexity int) int
-		Error func(childComplexity int) int
-		Info  func(childComplexity int) int
-		Log   func(childComplexity int) int
+		Data   func(childComplexity int) int
+		Error  func(childComplexity int) int
+		Events func(childComplexity int) int
+		Info   func(childComplexity int) int
+		Log    func(childComplexity int) int
 	}
 
 	TxFee struct {
@@ -463,6 +476,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Transaction.Success(childComplexity), true
 
+	case "TransactionEvent.attrs":
+		if e.complexity.TransactionEvent.Attrs == nil {
+			break
+		}
+
+		return e.complexity.TransactionEvent.Attrs(childComplexity), true
+
+	case "TransactionEvent.func":
+		if e.complexity.TransactionEvent.Func == nil {
+			break
+		}
+
+		return e.complexity.TransactionEvent.Func(childComplexity), true
+
+	case "TransactionEvent.pkg_path":
+		if e.complexity.TransactionEvent.PkgPath == nil {
+			break
+		}
+
+		return e.complexity.TransactionEvent.PkgPath(childComplexity), true
+
+	case "TransactionEvent.type":
+		if e.complexity.TransactionEvent.Type == nil {
+			break
+		}
+
+		return e.complexity.TransactionEvent.Type(childComplexity), true
+
+	case "TransactionEventAttribute.key":
+		if e.complexity.TransactionEventAttribute.Key == nil {
+			break
+		}
+
+		return e.complexity.TransactionEventAttribute.Key(childComplexity), true
+
+	case "TransactionEventAttribute.value":
+		if e.complexity.TransactionEventAttribute.Value == nil {
+			break
+		}
+
+		return e.complexity.TransactionEventAttribute.Value(childComplexity), true
+
 	case "TransactionMessage.route":
 		if e.complexity.TransactionMessage.Route == nil {
 			break
@@ -497,6 +552,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TransactionResponse.Error(childComplexity), true
+
+	case "TransactionResponse.events":
+		if e.complexity.TransactionResponse.Events == nil {
+			break
+		}
+
+		return e.complexity.TransactionResponse.Events(childComplexity), true
 
 	case "TransactionResponse.info":
 		if e.complexity.TransactionResponse.Info == nil {
@@ -550,6 +612,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMsgCallInput,
 		ec.unmarshalInputMsgRunInput,
 		ec.unmarshalInputTransactionBankMessageInput,
+		ec.unmarshalInputTransactionEventAttributeInput,
+		ec.unmarshalInputTransactionEventInput,
 		ec.unmarshalInputTransactionFilter,
 		ec.unmarshalInputTransactionMessageInput,
 		ec.unmarshalInputTransactionVmMessageInput,
@@ -2796,8 +2860,277 @@ func (ec *executionContext) fieldContext_Transaction_response(ctx context.Contex
 				return ec.fieldContext_TransactionResponse_error(ctx, field)
 			case "data":
 				return ec.fieldContext_TransactionResponse_data(ctx, field)
+			case "events":
+				return ec.fieldContext_TransactionResponse_events(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TransactionResponse", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionEvent_type(ctx context.Context, field graphql.CollectedField, obj *model.TransactionEvent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionEvent_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionEvent_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionEvent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionEvent_pkg_path(ctx context.Context, field graphql.CollectedField, obj *model.TransactionEvent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionEvent_pkg_path(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PkgPath, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionEvent_pkg_path(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionEvent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionEvent_func(ctx context.Context, field graphql.CollectedField, obj *model.TransactionEvent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionEvent_func(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Func, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionEvent_func(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionEvent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionEvent_attrs(ctx context.Context, field graphql.CollectedField, obj *model.TransactionEvent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionEvent_attrs(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Attrs, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.TransactionEventAttribute)
+	fc.Result = res
+	return ec.marshalOTransactionEventAttribute2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttributeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionEvent_attrs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionEvent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_TransactionEventAttribute_key(ctx, field)
+			case "value":
+				return ec.fieldContext_TransactionEventAttribute_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TransactionEventAttribute", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionEventAttribute_key(ctx context.Context, field graphql.CollectedField, obj *model.TransactionEventAttribute) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionEventAttribute_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionEventAttribute_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionEventAttribute",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionEventAttribute_value(ctx context.Context, field graphql.CollectedField, obj *model.TransactionEventAttribute) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionEventAttribute_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionEventAttribute_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionEventAttribute",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3106,6 +3439,57 @@ func (ec *executionContext) fieldContext_TransactionResponse_data(ctx context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TransactionResponse_events(ctx context.Context, field graphql.CollectedField, obj *model.TransactionResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TransactionResponse_events(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Events(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]model.TransactionEvent)
+	fc.Result = res
+	return ec.marshalOTransactionEvent2ᚕgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TransactionResponse_events(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TransactionResponse",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "type":
+				return ec.fieldContext_TransactionEvent_type(ctx, field)
+			case "pkg_path":
+				return ec.fieldContext_TransactionEvent_pkg_path(ctx, field)
+			case "func":
+				return ec.fieldContext_TransactionEvent_func(ctx, field)
+			case "attrs":
+				return ec.fieldContext_TransactionEvent_attrs(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TransactionEvent", field.Name)
 		},
 	}
 	return fc, nil
@@ -5385,6 +5769,88 @@ func (ec *executionContext) unmarshalInputTransactionBankMessageInput(ctx contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputTransactionEventAttributeInput(ctx context.Context, obj interface{}) (model.TransactionEventAttributeInput, error) {
+	var it model.TransactionEventAttributeInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"key", "value"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Key = data
+		case "value":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Value = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTransactionEventInput(ctx context.Context, obj interface{}) (model.TransactionEventInput, error) {
+	var it model.TransactionEventInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"type", "pkg_path", "func", "attrs"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "type":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Type = data
+		case "pkg_path":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pkg_path"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PkgPath = data
+		case "func":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("func"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Func = data
+		case "attrs":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("attrs"))
+			data, err := ec.unmarshalOTransactionEventAttributeInput2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttributeInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Attrs = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context, obj interface{}) (model.TransactionFilter, error) {
 	var it model.TransactionFilter
 	asMap := map[string]interface{}{}
@@ -5392,7 +5858,7 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"from_block_height", "to_block_height", "from_index", "to_index", "from_gas_wanted", "to_gas_wanted", "from_gas_used", "to_gas_used", "hash", "message", "memo", "success"}
+	fieldsInOrder := [...]string{"from_block_height", "to_block_height", "from_index", "to_index", "from_gas_wanted", "to_gas_wanted", "from_gas_used", "to_gas_used", "hash", "message", "memo", "success", "events"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -5483,6 +5949,13 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 				return it, err
 			}
 			it.Success = data
+		case "events":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("events"))
+			data, err := ec.unmarshalOTransactionEventInput2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Events = data
 		}
 	}
 
@@ -6198,6 +6671,101 @@ func (ec *executionContext) _Transaction(ctx context.Context, sel ast.SelectionS
 	return out
 }
 
+var transactionEventImplementors = []string{"TransactionEvent"}
+
+func (ec *executionContext) _TransactionEvent(ctx context.Context, sel ast.SelectionSet, obj *model.TransactionEvent) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, transactionEventImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TransactionEvent")
+		case "type":
+			out.Values[i] = ec._TransactionEvent_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pkg_path":
+			out.Values[i] = ec._TransactionEvent_pkg_path(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "func":
+			out.Values[i] = ec._TransactionEvent_func(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "attrs":
+			out.Values[i] = ec._TransactionEvent_attrs(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var transactionEventAttributeImplementors = []string{"TransactionEventAttribute"}
+
+func (ec *executionContext) _TransactionEventAttribute(ctx context.Context, sel ast.SelectionSet, obj *model.TransactionEventAttribute) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, transactionEventAttributeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TransactionEventAttribute")
+		case "key":
+			out.Values[i] = ec._TransactionEventAttribute_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "value":
+			out.Values[i] = ec._TransactionEventAttribute_value(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var transactionMessageImplementors = []string{"TransactionMessage"}
 
 func (ec *executionContext) _TransactionMessage(ctx context.Context, sel ast.SelectionSet, obj *model.TransactionMessage) graphql.Marshaler {
@@ -6278,6 +6846,8 @@ func (ec *executionContext) _TransactionResponse(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "events":
+			out.Values[i] = ec._TransactionResponse_events(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6846,6 +7416,30 @@ func (ec *executionContext) marshalNTransaction2ᚖgithubᚗcomᚋgnolangᚋtx�
 		return graphql.Null
 	}
 	return ec._Transaction(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTransactionEvent2githubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEvent(ctx context.Context, sel ast.SelectionSet, v model.TransactionEvent) graphql.Marshaler {
+	return ec._TransactionEvent(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTransactionEventAttribute2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttribute(ctx context.Context, sel ast.SelectionSet, v *model.TransactionEventAttribute) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TransactionEventAttribute(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTransactionEventAttributeInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttributeInput(ctx context.Context, v interface{}) (*model.TransactionEventAttributeInput, error) {
+	res, err := ec.unmarshalInputTransactionEventAttributeInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNTransactionEventInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventInput(ctx context.Context, v interface{}) (*model.TransactionEventInput, error) {
+	res, err := ec.unmarshalInputTransactionEventInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNTransactionFilter2githubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionFilter(ctx context.Context, v interface{}) (model.TransactionFilter, error) {
@@ -7521,6 +8115,140 @@ func (ec *executionContext) unmarshalOTransactionBankMessageInput2ᚖgithubᚗco
 	}
 	res, err := ec.unmarshalInputTransactionBankMessageInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTransactionEvent2ᚕgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventᚄ(ctx context.Context, sel ast.SelectionSet, v []model.TransactionEvent) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTransactionEvent2githubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEvent(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalOTransactionEventAttribute2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttributeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.TransactionEventAttribute) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTransactionEventAttribute2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttribute(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalOTransactionEventAttributeInput2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttributeInputᚄ(ctx context.Context, v interface{}) ([]*model.TransactionEventAttributeInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.TransactionEventAttributeInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNTransactionEventAttributeInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventAttributeInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOTransactionEventInput2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventInputᚄ(ctx context.Context, v interface{}) ([]*model.TransactionEventInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.TransactionEventInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNTransactionEventInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionEventInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) marshalOTransactionMessage2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionMessage(ctx context.Context, sel ast.SelectionSet, v *model.TransactionMessage) graphql.Marshaler {

--- a/serve/graph/model/models_gen.go
+++ b/serve/graph/model/models_gen.go
@@ -213,6 +213,50 @@ type TransactionBankMessageInput struct {
 	Send *BankMsgSendInput `json:"send,omitempty"`
 }
 
+// `TransactionEvent' is the event information emitted by the transaction.
+// It has `log`, `info`, `error`, and `data`.
+type TransactionEvent struct {
+	// `type` is the type of transaction event emitted.
+	Type string `json:"type"`
+	// `pkg_path` is the path to the package that emitted the event.
+	PkgPath string `json:"pkg_path"`
+	// `func` is the name of the function that emitted the event.
+	Func string `json:"func"`
+	// `attrs` is the event's attribute information.
+	Attrs []*TransactionEventAttribute `json:"attrs,omitempty"`
+}
+
+// `TransactionEventAttribute` is the attributes that the event has.
+// It has `key` and `value`.
+type TransactionEventAttribute struct {
+	// The key of the event attribute.
+	Key string `json:"key"`
+	// The value of the event attribute.
+	Value string `json:"value"`
+}
+
+// Transaction event's attribute to filter transaction.
+// "TransactionEventAttributeInput" can be configured as a filter with a event attribute's `key` and `value`.
+type TransactionEventAttributeInput struct {
+	// `key` is the key of the event attribute.
+	Key *string `json:"key,omitempty"`
+	// `value` is the value of the event attribute.
+	Value *string `json:"value,omitempty"`
+}
+
+// Transaction's event to filter transactions.
+// "TransactionMessageInput" can be configured as a filter with a transaction event's `type` and `pkg_path` and `func`, and `attrs`.
+type TransactionEventInput struct {
+	// `type` is the type of transaction event emitted.
+	Type *string `json:"type,omitempty"`
+	// `pkg_path` is the path to the package that emitted the event.
+	PkgPath *string `json:"pkg_path,omitempty"`
+	// `func` is the name of the function that emitted the event.
+	Func *string `json:"func,omitempty"`
+	// `attrs` filters transactions whose events contain attributes.
+	Attrs []*TransactionEventAttributeInput `json:"attrs,omitempty"`
+}
+
 // Filters for querying Transactions within specified criteria related to their execution and placement within Blocks.
 type TransactionFilter struct {
 	// Minimum block height from which to start fetching Transactions, inclusive. Aids in scoping the search to recent Transactions.
@@ -243,6 +287,9 @@ type TransactionFilter struct {
 	// `success` is whether the transaction was successful or not.
 	// `success` enables you to filter between successful and unsuccessful transactions.
 	Success *bool `json:"success,omitempty"`
+	// `events` are the events that the transaction has emitted.
+	// `events` filters transactions with specific events.
+	Events []*TransactionEventInput `json:"events,omitempty"`
 }
 
 // Transaction's message to filter Transactions.

--- a/serve/graph/model/transaction.go
+++ b/serve/graph/model/transaction.go
@@ -149,6 +149,22 @@ func (tr *TransactionResponse) Data() string {
 	return string(tr.response.Data)
 }
 
+func (tr *TransactionResponse) Events() []TransactionEvent {
+	events := make([]TransactionEvent, 0)
+
+	data, err := json.Marshal(tr.response.Events)
+	if err != nil {
+		return events
+	}
+
+	err = json.Unmarshal(data, &events)
+	if err != nil {
+		return events
+	}
+
+	return events
+}
+
 type TransactionMessage struct {
 	Value   MessageValue
 	Route   string

--- a/serve/graph/schema/filter/transaction_filter.graphql
+++ b/serve/graph/schema/filter/transaction_filter.graphql
@@ -65,6 +65,54 @@ input TransactionFilter {
   `success` enables you to filter between successful and unsuccessful transactions.
   """
   success: Boolean
+
+  """
+  `events` are the events that the transaction has emitted.
+  `events` filters transactions with specific events.
+  """
+  events: [TransactionEventInput!]
+}
+
+"""
+Transaction's event to filter transactions.
+"TransactionEventInput" can be configured as a filter with a transaction event's `type` and `pkg_path` and `func`, and `attrs`.
+"""
+input TransactionEventInput {
+  """
+  `type` is the type of transaction event emitted.
+  """
+  type: String
+
+  """
+  `pkg_path` is the path to the package that emitted the event.
+  """
+  pkg_path: String
+
+  """
+  `func` is the name of the function that emitted the event.
+  """
+  func: String
+
+  """
+  `attrs` filters transactions whose events contain attributes.
+  """
+  attrs: [TransactionEventAttributeInput!]
+}
+
+"""
+Transaction event's attribute to filter transaction.
+"TransactionEventAttributeInput" can be configured as a filter with a event attribute's `key` and `value`.
+"""
+input TransactionEventAttributeInput {
+  """
+  `key` is the key of the event attribute.
+  """
+  key: String
+
+  """
+  `value` is the value of the event attribute.
+  """
+  value: String
 }
 
 """

--- a/serve/graph/schema/types/transaction.graphql
+++ b/serve/graph/schema/types/transaction.graphql
@@ -299,4 +299,51 @@ type TransactionResponse {
   The response data associated with the Transaction execution, if any.
   """
   data: String!
+
+  """
+  The emitted events associated with the transaction execution, if any.
+  """
+  events: [TransactionEvent!]
+}
+
+"""
+`TransactionEvent' is the event information emitted by the transaction.
+It has `log`, `info`, `error`, and `data`.
+"""
+type TransactionEvent {
+  """
+  `type` is the type of transaction event emitted.
+  """
+  type: String!
+
+  """
+  `pkg_path` is the path to the package that emitted the event.
+  """
+  pkg_path: String!
+
+  """
+  `func` is the name of the function that emitted the event.
+  """
+  func: String!
+
+  """
+  `attrs` is the event's attribute information.
+  """
+  attrs: [TransactionEventAttribute!]
+}
+
+"""
+`TransactionEventAttribute` is the attributes that the event has.
+It has `key` and `value`.
+"""
+type TransactionEventAttribute {
+  """
+  The key of the event attribute.
+  """
+  key: String!
+
+  """
+  The value of the event attribute.
+  """
+  value: String!
 }


### PR DESCRIPTION
# Descriptions
Based on issue [#134](https://github.com/gnolang/tx-indexer/issues/42), 
Add Events to the GraphQL transaction model.
The Event structure follows [emit_event.go](https://github.com/gnolang/gno/blob/0fc011a87032e0203eada3116e88a395150554a6/gnovm/stdlibs/std/emit_event.go#L48-L53). 

This is what works for this PR.

- Add Events to the transaction response model. 
- Adds the feature to filter transactions by events. 

### Examples
#### Filter by transaction event and get the event  
<img width="2560" alt="image" src="https://github.com/gnolang/tx-indexer/assets/112360739/11e00e22-4fa8-4ac9-b41f-d385946a0eaf">
