### PR TITLE
feat: pin codegen and check it on CI

### DIFF
--- a/.github/workflows/gen.yaml
+++ b/.github/workflows/gen.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -14,7 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          args: --config=./.github/golangci.yaml
+      - name: Generate code
+        run: make generate
+
+      - name: Check that there is no diff
+        run: git diff --exit-code

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,3 +12,7 @@ jobs:
   test:
     name: Go Test
     uses: ./.github/workflows/test.yaml
+
+  codegen:
+    name: Go Codegen
+    uses: ./.github/workflows/gen.yaml

--- a/serve/graph/model/models_gen.go
+++ b/serve/graph/model/models_gen.go
@@ -96,7 +96,7 @@ type EventInput struct {
 }
 
 // `GnoEvent` is the event information exported by the Gno VM.
-// It has `log`, `info`, `error`, and `data`.
+// It has `type`, `pkg_path`, `func`, and `attrs`.
 type GnoEvent struct {
 	// `type` is the type of transaction event emitted.
 	Type string `json:"type"`
@@ -342,60 +342,13 @@ type UnexpectedMessage struct {
 func (UnexpectedMessage) IsMessageValue() {}
 
 // `UnknownEvent` is an unknown event type.
-// It has `key` and `value`.
+// It has `value`.
 type UnknownEvent struct {
-	// `value` is an event string..
+	// `value` is an raw event string.
 	Value string `json:"value"`
 }
 
 func (UnknownEvent) IsEvent() {}
-
-// `MessageType` is message type of the transaction.
-// `MessageType` has the values `send`, `exec`, `add_package`, and `run`.
-type EventType string
-
-const (
-	// The route value for this message type is `bank`, and the value for transactional messages is `BankMsgSend`.
-	// This is a transaction message used when sending native tokens.
-	EventTypeGno EventType = "gno"
-	// The route value for this message type is `vm`, and the value for transactional messages is `MsgCall`.
-	// This is a transaction message that executes a function in realm or package that is deployed in the GNO chain.
-	EventTypeUnknown EventType = "unknown"
-)
-
-var AllEventType = []EventType{
-	EventTypeGno,
-	EventTypeUnknown,
-}
-
-func (e EventType) IsValid() bool {
-	switch e {
-	case EventTypeGno, EventTypeUnknown:
-		return true
-	}
-	return false
-}
-
-func (e EventType) String() string {
-	return string(e)
-}
-
-func (e *EventType) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = EventType(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid EventType", str)
-	}
-	return nil
-}
-
-func (e EventType) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
 
 // `MessageRoute` is route type of the transactional message.
 // `MessageRoute` has the values of vm and bank.

--- a/serve/graph/resolver.go
+++ b/serve/graph/resolver.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/99designs/gqlgen generate
+//go:generate go run github.com/99designs/gqlgen@v0.17.45 generate
 
 package graph
 


### PR DESCRIPTION
This pins the `99designs/gqlgen` version and check that there if no diff after `make generate` on CI

There is a big removal in models_gen.go but I think this is probably a desynced codegen since no tests breaks and the cmd builds correctly, this PR aims to avoid these situations.