### PR TITLE
[infra] proposing detailed Multistage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# git + GitHub stuff
+.git*
+*.yml
+
+# Markdown
+README.md
+LICENSE.md
+
+Dockerfile*
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,5 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 FROM alpine:3.20 AS tx-indexer
 
-# Set the timezone and install CA certificates
-# RUN apk --no-cache add ca-certificates tzdata
-
 COPY --from=builder /app/indexer /usr/local/bin/indexer
 ENTRYPOINT [ "/usr/local/bin/indexer" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,3 +1,5 @@
+# This Dockerfile is only useful for Goreleaser task
+# https://goreleaser.com/customization/docker/
 FROM scratch
 COPY tx-indexer /
 ENTRYPOINT [ "/tx-indexer" ]


### PR DESCRIPTION
A proposal for a much detailed multistaged Dockerfile.

* it builds faster since it leverages caches
* it adds only the strictly necessary files (context copies to docker image is faster)

Further improvements:

* replace Binary base image to `scratch` from `alpine`

The latter should be evaluated carefully since such base image would not enable any access, neither attaching a terminal