### PR TITLE
feat: add cursor-based pagination options

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -81,6 +81,9 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
+  Cursor:
+    model:
+      - github.com/gnolang/tx-indexer/serve/graph/model.Cursor
   Block:
     model:
       - github.com/gnolang/tx-indexer/serve/graph/model.Block

--- a/internal/mock/storage.go
+++ b/internal/mock/storage.go
@@ -51,7 +51,7 @@ func (m *Storage) GetTxByHash(txHash string) (*types.TxResult, error) {
 }
 
 // BlockIterator iterates over Blocks, limiting the results to be between the provided block numbers
-func (m *Storage) BlockIterator(_, _ uint64) (storage.Iterator[*types.Block], error) {
+func (m *Storage) BlockIterator(_, _ uint64, _ bool) (storage.Iterator[*types.Block], error) {
 	panic("not implemented") // TODO: Implement
 }
 
@@ -62,6 +62,7 @@ func (m *Storage) TxIterator(
 	_ uint64,
 	_,
 	_ uint32,
+	_ bool,
 ) (storage.Iterator[*types.TxResult], error) {
 	panic("not implemented") // TODO: Implement
 }

--- a/serve/graph/model/block_list.go
+++ b/serve/graph/model/block_list.go
@@ -1,0 +1,23 @@
+package model
+
+func NewBlockList(edges []*BlockListEdge, hasNext bool) *BlockList {
+	pageInfo := NewPageInfo(nil, nil, hasNext)
+
+	if len(edges) > 0 {
+		first := edges[0]
+		last := edges[len(edges)-1]
+		pageInfo = NewPageInfo(&first.Cursor, &last.Cursor, hasNext)
+	}
+
+	return &BlockList{
+		PageInfo: pageInfo,
+		Edges:    edges,
+	}
+}
+
+func NewBlockListEdge(block *Block) *BlockListEdge {
+	return &BlockListEdge{
+		Cursor: NewCursor(block.ID()),
+		Block:  block,
+	}
+}

--- a/serve/graph/model/cursor.go
+++ b/serve/graph/model/cursor.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	"encoding/base64"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// Cursor represents a string key of an element position in a sequential list of edges.
+type Cursor string
+
+// Create a cursor by base64-encoding the ID.
+func NewCursor(id string) Cursor {
+	return Cursor(base64.StdEncoding.EncodeToString([]byte(id)))
+}
+
+// UnmarshalGraphQL unmarshal incoming cursor into a local variable.
+func (c *Cursor) UnmarshalGraphQL(input interface{}) error {
+	var err error
+
+	switch input := input.(type) {
+	case string:
+		*c = Cursor(input)
+	case int32:
+		*c = Cursor(strconv.Itoa(int(input)))
+	default:
+		err = errors.New("wrong cursor type")
+	}
+
+	return err
+}
+
+// MarshalJSON encodes a cursor to JSON for transport.
+func (c Cursor) MarshalJSON() ([]byte, error) {
+	return strconv.AppendQuote(nil, string(c)), nil
+}
+
+// Decodes and returns the base64-encoded ID, which is the value of the cursor.
+func (c *Cursor) ID() (string, error) {
+	if c == nil {
+		return "", nil
+	}
+
+	base64Str := string(*c)
+
+	decoded, err := base64.StdEncoding.DecodeString(base64Str)
+	if err != nil {
+		return "", err
+	}
+
+	return string(decoded), nil
+}
+
+// Get the block height from the ID of the Cursor.
+func (c *Cursor) BlockHeight() (uint64, error) {
+	id, err := c.ID()
+	if err != nil {
+		return 0, err
+	}
+
+	if id == "" {
+		return 0, nil
+	}
+
+	blockHeight, err := strconv.ParseUint(id, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return blockHeight, nil
+}
+
+// Get the values of block height and transaction index by the ID of the Cursor.
+func (c *Cursor) BlockHeightWithIndex() (uint64, uint32, error) {
+	id, err := c.ID()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if id == "" {
+		return 0, 0, nil
+	}
+
+	afterParams := strings.Split(id, "_")
+	if len(afterParams) < 2 {
+		return 0, 0, errors.New("wrong cursor type")
+	}
+
+	blockHeight, err := strconv.ParseUint(afterParams[0], 0, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	index, err := strconv.ParseUint(afterParams[1], 0, 32)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return blockHeight, uint32(index), nil
+}

--- a/serve/graph/model/models_gen.go
+++ b/serve/graph/model/models_gen.go
@@ -71,6 +71,20 @@ type BlockFilter struct {
 	ToTime *time.Time `json:"to_time,omitempty"`
 }
 
+// BlockList is a list of block edges provided by sequential access request.
+type BlockList struct {
+	// Edges contains provided edges of the sequential list.
+	Edges []*BlockListEdge `json:"edges"`
+	// PageInfo is an information about the current page of block edges.
+	PageInfo *PageInfo `json:"pageInfo"`
+}
+
+// BlockListEdge is a single edge in a sequential list of blocks.
+type BlockListEdge struct {
+	Block  *Block `json:"block"`
+	Cursor Cursor `json:"cursor"`
+}
+
 // Defines a transaction within a block, its execution specifics and content.
 type BlockTransaction struct {
 	// Hash computes the TMHASH hash of the wire encoded transaction.
@@ -272,6 +286,16 @@ type MsgRunInput struct {
 	Package *MemPackageInput `json:"package,omitempty"`
 }
 
+// PageInfo contains information about a sequential access list page.
+type PageInfo struct {
+	// `first` is the cursor of the first edge of the edges list. null for empty list.
+	First *Cursor `json:"first,omitempty"`
+	// `last` if the cursor of the last edge of the edges list. null for empty list.
+	Last *Cursor `json:"last,omitempty"`
+	// `hasNext` specifies if there is another edge after the last one.
+	HasNext bool `json:"hasNext"`
+}
+
 // Root Query type to fetch data about Blocks and Transactions based on filters or retrieve the latest block height.
 type Query struct {
 }
@@ -322,6 +346,18 @@ type TransactionFilter struct {
 	// `events` is entered as an array and works exclusively.
 	// ex) `events[0] || events[1] || events[2]`
 	Events []*EventInput `json:"events,omitempty"`
+}
+
+// TransactionList is a list of transaction edges provided by sequential access request.
+type TransactionList struct {
+	Edges    []*TransactionListEdge `json:"edges"`
+	PageInfo *PageInfo              `json:"pageInfo"`
+}
+
+// TransactionListEdge is a single edge in a sequential list of transactions.
+type TransactionListEdge struct {
+	Transaction *Transaction `json:"transaction"`
+	Cursor      Cursor       `json:"cursor"`
 }
 
 // Transaction's message to filter Transactions.

--- a/serve/graph/model/page_info.go
+++ b/serve/graph/model/page_info.go
@@ -1,0 +1,9 @@
+package model
+
+func NewPageInfo(first, last *Cursor, hasNext bool) *PageInfo {
+	return &PageInfo{
+		First:   first,
+		Last:    last,
+		HasNext: hasNext,
+	}
+}

--- a/serve/graph/model/transaction_list.go
+++ b/serve/graph/model/transaction_list.go
@@ -1,0 +1,23 @@
+package model
+
+func NewTransactionList(edges []*TransactionListEdge, hasNext bool) *TransactionList {
+	pageInfo := NewPageInfo(nil, nil, hasNext)
+
+	if len(edges) > 0 {
+		first := edges[0]
+		last := edges[len(edges)-1]
+		pageInfo = NewPageInfo(&first.Cursor, &last.Cursor, hasNext)
+	}
+
+	return &TransactionList{
+		PageInfo: pageInfo,
+		Edges:    edges,
+	}
+}
+
+func NewTransactionListEdge(transaction *Transaction) *TransactionListEdge {
+	return &TransactionListEdge{
+		Cursor:      NewCursor(transaction.ID()),
+		Transaction: transaction,
+	}
+}

--- a/serve/graph/schema/query.graphql
+++ b/serve/graph/schema/query.graphql
@@ -4,13 +4,15 @@ Root Query type to fetch data about Blocks and Transactions based on filters or 
 type Query {
   """
   Retrieves a list of Transactions that match the given filter criteria. If the result is incomplete due to errors, both partial results and errors are returned.
+  Options of `after`, `size`, and `ascending` can be used to utilize pagination.
   """
-  transactions(filter: TransactionFilter!): [Transaction!]
+  transactions(filter: TransactionFilter!, after: Cursor, size: Int, ascending: Boolean! = true): TransactionList!
 
   """
   Fetches Blocks matching the specified filter criteria. Incomplete results due to errors return both the partial Blocks and the associated errors.
+  Options of `after`, `size`, and `ascending` can be used to utilize pagination.
   """
-  blocks(filter: BlockFilter!): [Block!]
+  blocks(filter: BlockFilter!, after: Cursor, size: Int, ascending: Boolean! = true): BlockList!
 
   """
   Returns the height of the most recently processed Block by the blockchain indexer, indicating the current length of the blockchain.

--- a/serve/graph/schema/schema.graphql
+++ b/serve/graph/schema/schema.graphql
@@ -7,3 +7,8 @@ schema {
 Field representing a point on time. It is following the RFC3339Nano format ("2006-01-02T15:04:05.999999999Z07:00")
 """
 scalar Time
+
+"""
+Cursor is a string representing position in a sequential list of edges.
+"""
+scalar Cursor

--- a/serve/graph/schema/types/block_list.graphql
+++ b/serve/graph/schema/types/block_list.graphql
@@ -1,0 +1,23 @@
+"""
+BlockList is a list of block edges provided by sequential access request.
+"""
+type BlockList {
+  """
+  Edges contains provided edges of the sequential list.
+  """
+  edges: [BlockListEdge!]!
+
+  """
+  PageInfo is an information about the current page of block edges.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+BlockListEdge is a single edge in a sequential list of blocks.
+"""
+type BlockListEdge {
+  block: Block!
+
+  cursor: Cursor!
+}

--- a/serve/graph/schema/types/page_info.graphql
+++ b/serve/graph/schema/types/page_info.graphql
@@ -1,0 +1,19 @@
+"""
+PageInfo contains information about a sequential access list page.
+"""
+type PageInfo {
+  """
+  `first` is the cursor of the first edge of the edges list. null for empty list.
+  """
+  first: Cursor
+
+  """
+  `last` if the cursor of the last edge of the edges list. null for empty list.
+  """
+  last: Cursor
+
+  """
+  `hasNext` specifies if there is another edge after the last one.
+  """
+  hasNext: Boolean!
+}

--- a/serve/graph/schema/types/transaction_list.graphql
+++ b/serve/graph/schema/types/transaction_list.graphql
@@ -1,0 +1,19 @@
+"""
+TransactionList is a list of transaction edges provided by sequential access request.
+"""
+type TransactionList {
+  # Edges contains provided edges of the sequential list.
+  edges: [TransactionListEdge!]!
+
+  # PageInfo is an information about the current page of transaction edges.
+  pageInfo: PageInfo!
+}
+
+"""
+TransactionListEdge is a single edge in a sequential list of transactions.
+"""
+type TransactionListEdge {
+  transaction: Transaction!
+
+  cursor: Cursor!
+}

--- a/storage/pebble_test.go
+++ b/storage/pebble_test.go
@@ -126,7 +126,7 @@ func TestStorageIters(t *testing.T) {
 
 	require.NoError(t, wb.Commit())
 
-	it, err := s.TxIterator(0, 0, 0, 3)
+	it, err := s.TxIterator(0, 0, 0, 3, true)
 	require.NoError(t, err)
 
 	txCount := 0
@@ -149,7 +149,7 @@ func TestStorageIters(t *testing.T) {
 
 	defer require.NoError(t, it.Close())
 
-	it2, err := s.BlockIterator(0, 2)
+	it2, err := s.BlockIterator(0, 2, true)
 	require.NoError(t, err)
 
 	blockCount := 0
@@ -167,11 +167,11 @@ func TestStorageIters(t *testing.T) {
 		blockCount++
 	}
 
-	require.Equal(t, 2, blockCount)
+	require.Equal(t, 3, blockCount)
 
 	defer require.NoError(t, it2.Close())
 
-	it, err = s.TxIterator(0, 0, 20000, 30000)
+	it, err = s.TxIterator(0, 0, 20000, 30000, true)
 	require.NoError(t, err)
 
 	txCount = 0

--- a/storage/types.go
+++ b/storage/types.go
@@ -29,11 +29,17 @@ type Reader interface {
 	GetTxByHash(txHash string) (*types.TxResult, error)
 
 	// BlockIterator iterates over Blocks, limiting the results to be between the provided block numbers
-	BlockIterator(fromBlockNum, toBlockNum uint64) (Iterator[*types.Block], error)
+	BlockIterator(fromBlockNum, toBlockNum uint64, ascending bool) (Iterator[*types.Block], error)
 
 	// TxIterator iterates over transactions, limiting the results to be between the provided block numbers
 	// and transaction indexes
-	TxIterator(fromBlockNum, toBlockNum uint64, fromTxIndex, toTxIndex uint32) (Iterator[*types.TxResult], error)
+	TxIterator(
+		fromBlockNum,
+		toBlockNum uint64,
+		fromTxIndex,
+		toTxIndex uint32,
+		ascending bool,
+	) (Iterator[*types.TxResult], error)
 }
 
 type Iterator[T any] interface {


### PR DESCRIPTION
# Descriptions

Add a query option to utilize the indexer.

Changes in this PR.
- Added `after`, `size`, `ascending` options to `transactions`, `blocks` query input parameters.
    - `after`: Retrieves the next value at the after cursor. 
    - `size`: The size of the list being retrieved. 
    - `ascending`: Sort in ascending or descending order. (default: true)

- Added `pageInfo` and `edges` data to response.
    - `pageInfo`: PageInfo is an information about the current page of edges.
    - `edges`: Edges contains provided edges of the sequential list. The edge data can retrieve cursor information along with data such as block, transaction, etc.

### Example
![image](https://github.com/user-attachments/assets/9da83ae3-22ce-44ff-af3b-b228963c7328)
