### PR TITLE
Two suggested fixes for the tx-indexer Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git clone https://github.com/gnolang/tx-indexer.git
 2. **Build the binary**
 
 ```bash
+cd tx-indexer
 make build
 ```
 


### PR DESCRIPTION
Ran into these as I was doing the take-home assignment.

1: cd tx-indexer before running make:
This only cost me a few moments before I realized what to do, but this is a few moments best saved.

2: filter "messages" not "message" : this doesn't work correctly as provided and should be fixed either in the example or in the implementation.