### PR TITLE
Add GH check to avoid backward incompatible schema changes

### DIFF
--- a/.github/workflows/gqlCheck.yaml
+++ b/.github/workflows/gqlCheck.yaml
@@ -1,0 +1,53 @@
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Block Filters
+          schema: 'main:serve/graph/schema/filter/block_filter.graphql'
+          rules: |
+            safeUnreachable
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Transaction Filters
+          schema: 'main:serve/graph/schema/filter/transaction_filter.graphql'
+          rules: |
+            safeUnreachable
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Block Types
+          schema: 'main:serve/graph/schema/types/block.graphql'
+          rules: |
+            safeUnreachable
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Transaction Types
+          schema: 'main:serve/graph/schema/types/transaction.graphql'
+          rules: |
+            safeUnreachable
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Queries
+          schema: 'main:serve/graph/schema/query.graphql'
+          rules: |
+            suppressRemovalOfDeprecatedField
+            safeUnreachable
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Subscriptions
+          schema: 'main:serve/graph/schema/subscription.graphql'
+          rules: |
+            suppressRemovalOfDeprecatedField
+            safeUnreachable
+      - uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate Schema
+          schema: 'main:serve/graph/schema/schema.graphql'

--- a/.github/workflows/gqlCheck.yaml
+++ b/.github/workflows/gqlCheck.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,3 +16,7 @@ jobs:
   codegen:
     name: Go Codegen
     uses: ./.github/workflows/gen.yaml
+  
+  grapqlcheck:
+    name: GraphQL Check
+    uses: ./.github/workflows/gqlCheck.yaml


### PR DESCRIPTION
We have already made some incompatible changes. This check is to avoid them and make users trust that the API won't change in an incompatible way unless a method is deprecated.