### PR TITLE
fix: Rollback backward incompatible change

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A GraphQL playground is available at `/graphql`. There you have all the document
 ```graphql
 {
   transactions(
-    filter: { messages: {vm_param: {add_package: {}}}}
+    filter: { message: {vm_param: {add_package: {}}}}
   ) {
     index
     hash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gnolang/tx-indexer
 
-go 1.22
+go 1.22.7
 
 require (
 	github.com/99designs/gqlgen v0.17.49

--- a/serve/graph/generated.go
+++ b/serve/graph/generated.go
@@ -6974,7 +6974,7 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"from_block_height", "to_block_height", "from_index", "to_index", "from_gas_wanted", "to_gas_wanted", "from_gas_used", "to_gas_used", "hash", "messages", "memo", "success", "events"}
+	fieldsInOrder := [...]string{"from_block_height", "to_block_height", "from_index", "to_index", "from_gas_wanted", "to_gas_wanted", "from_gas_used", "to_gas_used", "hash", "message", "memo", "success", "events"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -7044,13 +7044,13 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 				return it, err
 			}
 			it.Hash = data
-		case "messages":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("messages"))
+		case "message":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("message"))
 			data, err := ec.unmarshalOTransactionMessageInput2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionMessageInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Messages = data
+			it.Message = data
 		case "memo":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("memo"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)

--- a/serve/graph/model/models_gen.go
+++ b/serve/graph/model/models_gen.go
@@ -307,11 +307,11 @@ type TransactionFilter struct {
 	ToGasUsed *int `json:"to_gas_used,omitempty"`
 	// Hash from Transaction content in base64 encoding. If this filter is used, any other filter will be ignored.
 	Hash *string `json:"hash,omitempty"`
-	// Transaction's message to filter Transactions.
-	// `messages` can be configured as a filter with a transaction message's `router` and `type` and `parameters(bank / vm)`.
-	// `messages` is entered as an array and works exclusively.
-	// ex) `messages[0] || messages[1] || messages[2]`
-	Messages []*TransactionMessageInput `json:"messages,omitempty"`
+	// Transaction's messages to filter Transactions.
+	// `message` can be configured as a filter with a transaction message's `router` and `type` and `parameters(bank / vm)`.
+	// `message` is entered as an array and works exclusively.
+	// ex) `message[0] || message[1] || message[2]`
+	Message []*TransactionMessageInput `json:"message,omitempty"`
 	// `memo` are string information stored within a transaction.
 	// `memo` can be utilized to find or distinguish transactions.
 	// For example, when trading a specific exchange, you would utilize the memo field of the transaction.

--- a/serve/graph/schema/filter/transaction_filter.graphql
+++ b/serve/graph/schema/filter/transaction_filter.graphql
@@ -48,12 +48,12 @@ input TransactionFilter {
   hash: String
 
   """
-  Transaction's message to filter Transactions.
-  `messages` can be configured as a filter with a transaction message's `router` and `type` and `parameters(bank / vm)`.
-  `messages` is entered as an array and works exclusively.
-  ex) `messages[0] || messages[1] || messages[2]`
+  Transaction's messages to filter Transactions.
+  `message` can be configured as a filter with a transaction message's `router` and `type` and `parameters(bank / vm)`.
+  `message` is entered as an array and works exclusively.
+  ex) `message[0] || message[1] || message[2]`
   """
-  messages: [TransactionMessageInput!]
+  message: [TransactionMessageInput!]
 
   """
   `memo` are string information stored within a transaction.

--- a/serve/graph/transaction_filter.go
+++ b/serve/graph/transaction_filter.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/gnolang/gno/tm2/pkg/std"
+
 	"github.com/gnolang/tx-indexer/serve/graph/model"
 )
 
@@ -30,7 +31,7 @@ func FilteredTransactionBy(tx *model.Transaction, filter model.TransactionFilter
 		return false
 	}
 
-	if !filteredTransactionByMessages(tx, filter.Messages) {
+	if !filteredTransactionByMessages(tx, filter.Message) {
 		return false
 	}
 


### PR DESCRIPTION
Keep the 

Rollback field name change here: https://github.com/gnolang/tx-indexer/pull/74
Also Rollback https://github.com/gnolang/tx-indexer/pull/84

GraphQL supports slices of one element without adding brackets. Examples:

```
{
  transactions(filter: {message: [{vm_param: {add_package: {}}}]}) {
    hash
    messages {
      route
      typeUrl
    }
  }
}
```
```
{
  transactions(filter: {message: {vm_param: {add_package: {}}}}) {
    hash
    messages {
      route
      typeUrl
    }
  }
}
```

These two queries are the same.

CC @moul @zivkovicmilos  we must avoid breaking backward compatibility in our API.
