### PR TITLE
Fix: Proper handling of iterator ranges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.7
 
 require (
 	github.com/99designs/gqlgen v0.17.54
-	github.com/ajnavarro/gqlfiltergen v0.1.1
+	github.com/ajnavarro/gqlfiltergen v0.1.2
 	github.com/cockroachdb/pebble v1.1.2
 	github.com/gnolang/gno v0.2.1-0.20240927151923-69400d468d7b
 	github.com/go-chi/chi/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRB
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
-github.com/ajnavarro/gqlfiltergen v0.1.1 h1:gii29u7HafhyRzTXu6vcxnipwbETpMg3qSB2M3a7fc0=
-github.com/ajnavarro/gqlfiltergen v0.1.1/go.mod h1:uHvKxvSISkr7QFZnYlrXfpnEDI/UPpodVM/a/XkOjtU=
+github.com/ajnavarro/gqlfiltergen v0.1.2 h1:EeU7SFD/+7TJnh5tiWnoSFBb5oZnAWIAO5YJq4EtkSU=
+github.com/ajnavarro/gqlfiltergen v0.1.2/go.mod h1:uHvKxvSISkr7QFZnYlrXfpnEDI/UPpodVM/a/XkOjtU=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=

--- a/serve/graph/all.resolvers.go
+++ b/serve/graph/all.resolvers.go
@@ -126,12 +126,19 @@ func (r *queryResolver) LatestBlockHeight(ctx context.Context) (int, error) {
 // GetBlocks is the resolver for the getBlocks field.
 func (r *queryResolver) GetBlocks(ctx context.Context, where model.FilterBlock) ([]*model.Block, error) {
 	fromh, toh := where.MinMaxHeight()
+	dfromh := uint64(deref(fromh))
+	dtoh := uint64(deref(toh))
+	if fromh == toh && toh != nil {
+		// min element and max element are the same,
+		// so we only need to iterate over one element
+		dtoh++
+	}
 
 	it, err := r.
 		store.
 		BlockIterator(
-			uint64(deref(fromh)),
-			uint64(deref(toh)),
+			dfromh,
+			dtoh,
 		)
 	if err != nil {
 		return nil, gqlerror.Wrap(err)
@@ -196,15 +203,30 @@ func (r *queryResolver) GetTransactions(ctx context.Context, where model.FilterT
 	}
 
 	fromh, toh := where.MinMaxBlockHeight()
+	dfromh := uint64(deref(fromh))
+	dtoh := uint64(deref(toh))
+	if fromh == toh && toh != nil {
+		// min element and max element are the same,
+		// so we only need to iterate over one element
+		dtoh++
+	}
+
 	fromi, toi := where.MinMaxIndex()
+	dfromi := uint32(deref(fromi))
+	dtoi := uint32(deref(toi))
+	if fromi == toi && toi != nil {
+		// min element and max element are the same,
+		// so we only need to iterate over one element
+		dtoi++
+	}
 
 	it, err := r.
 		store.
 		TxIterator(
-			uint64(deref(fromh)),
-			uint64(deref(toh)),
-			uint32(deref(fromi)),
-			uint32(deref(toi)),
+			dfromh,
+			dtoh,
+			dfromi,
+			dtoi,
 		)
 	if err != nil {
 		return nil, gqlerror.Wrap(err)

--- a/serve/graph/model/filter_methods_gen.go
+++ b/serve/graph/model/filter_methods_gen.go
@@ -1294,15 +1294,9 @@ func (f *FilterTransaction) MinMaxIndex() (min *int, max *int) {
 			if min == nil || *f.Index.Gt < *min {
 				min = f.Index.Gt
 			}
-			if max == nil || *f.Index.Gt > *max {
-				max = f.Index.Gt
-			}
 		}
 
 		if f.Index.Lt != nil {
-			if min == nil || *f.Index.Lt < *min {
-				min = f.Index.Lt
-			}
 			if max == nil || *f.Index.Lt > *max {
 				max = f.Index.Lt
 			}
@@ -1354,15 +1348,9 @@ func (f *FilterTransaction) MinMaxBlockHeight() (min *int, max *int) {
 			if min == nil || *f.BlockHeight.Gt < *min {
 				min = f.BlockHeight.Gt
 			}
-			if max == nil || *f.BlockHeight.Gt > *max {
-				max = f.BlockHeight.Gt
-			}
 		}
 
 		if f.BlockHeight.Lt != nil {
-			if min == nil || *f.BlockHeight.Lt < *min {
-				min = f.BlockHeight.Lt
-			}
 			if max == nil || *f.BlockHeight.Lt > *max {
 				max = f.BlockHeight.Lt
 			}
@@ -2234,15 +2222,9 @@ func (f *FilterBlock) MinMaxHeight() (min *int, max *int) {
 			if min == nil || *f.Height.Gt < *min {
 				min = f.Height.Gt
 			}
-			if max == nil || *f.Height.Gt > *max {
-				max = f.Height.Gt
-			}
 		}
 
 		if f.Height.Lt != nil {
-			if min == nil || *f.Height.Lt < *min {
-				min = f.Height.Lt
-			}
 			if max == nil || *f.Height.Lt > *max {
 				max = f.Height.Lt
 			}


### PR DESCRIPTION
Update gqlfiltergen to properly return min-max values when obtained from LT and GT filters.

Add small glue code to handle min-max values when they are the same.