### PR TITLE
feat: add gas price RPC methods

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -225,6 +225,9 @@ func setupJSONRPC(
 	// Transaction handlers
 	j.RegisterTxEndpoints(db)
 
+	// Gas handlers
+	j.RegisterGasEndpoints(db)
+
 	// Block handlers
 	j.RegisterBlockEndpoints(db)
 

--- a/serve/filters/manager.go
+++ b/serve/filters/manager.go
@@ -85,6 +85,11 @@ func (f *Manager) NewTransactionSubscription(conn conns.WSConnection) string {
 	return f.newSubscription(filterSubscription.NewTransactionSubscription(conn))
 }
 
+// NewGasPriceSubscription creates gas fee subscriptions for blocks with transactions (over WS)
+func (f *Manager) NewGasPriceSubscription(conn conns.WSConnection) string {
+	return f.newSubscription(filterSubscription.NewGasPriceSubscription(conn))
+}
+
 // newSubscription adds new subscription to the subscription map
 func (f *Manager) newSubscription(subscription subscription) string {
 	return f.subscriptions.addSubscription(subscription)
@@ -122,6 +127,11 @@ func (f *Manager) subscribeToEvents() {
 
 					// Send events to all `newHeads` subscriptions
 					f.subscriptions.sendEvent(filterSubscription.NewHeadsEvent, newBlock.Block)
+
+					// Send an event to the `newGasPrice` subscription when creating a block with transactions
+					if len(newBlock.Results) > 0 {
+						f.subscriptions.sendEvent(filterSubscription.NewGasPriceEvent, newBlock.Results)
+					}
 
 					for _, txResult := range newBlock.Results {
 						// Apply transaction to filters

--- a/serve/filters/manager.go
+++ b/serve/filters/manager.go
@@ -129,8 +129,8 @@ func (f *Manager) subscribeToEvents() {
 					f.subscriptions.sendEvent(filterSubscription.NewHeadsEvent, newBlock.Block)
 
 					// Send an event to the `newGasPrice` subscription when creating a block with transactions
-					if len(newBlock.Results) > 0 {
-						f.subscriptions.sendEvent(filterSubscription.NewGasPriceEvent, newBlock.Results)
+					if len(newBlock.Block.Txs) > 0 {
+						f.subscriptions.sendEvent(filterSubscription.NewGasPriceEvent, newBlock.Block)
 					}
 
 					for _, txResult := range newBlock.Results {

--- a/serve/filters/subscription/gas.go
+++ b/serve/filters/subscription/gas.go
@@ -31,12 +31,12 @@ func (b *GasPriceSubscription) GetType() events.Type {
 }
 
 func (b *GasPriceSubscription) WriteResponse(id string, data any) error {
-	txResults, ok := data.([]*types.TxResult)
+	block, ok := data.(*types.Block)
 	if !ok {
 		return fmt.Errorf("unable to cast txResult, %s", data)
 	}
 
-	gasPrices, err := methods.GetGasPricesByTxResults(txResults)
+	gasPrices, err := methods.GetGasPricesByBlock(block)
 	if err != nil {
 		return err
 	}

--- a/serve/filters/subscription/gas.go
+++ b/serve/filters/subscription/gas.go
@@ -1,0 +1,45 @@
+package subscription
+
+import (
+	"fmt"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/tx-indexer/events"
+	"github.com/gnolang/tx-indexer/serve/conns"
+	"github.com/gnolang/tx-indexer/serve/methods"
+	"github.com/gnolang/tx-indexer/serve/spec"
+)
+
+const (
+	NewGasPriceEvent = "newGasPrice"
+)
+
+// GasPriceSubscription is the new-transactions type
+// subscription
+type GasPriceSubscription struct {
+	*baseSubscription
+}
+
+func NewGasPriceSubscription(conn conns.WSConnection) *GasPriceSubscription {
+	return &GasPriceSubscription{
+		baseSubscription: newBaseSubscription(conn),
+	}
+}
+
+func (b *GasPriceSubscription) GetType() events.Type {
+	return NewGasPriceEvent
+}
+
+func (b *GasPriceSubscription) WriteResponse(id string, data any) error {
+	txResults, ok := data.([]*types.TxResult)
+	if !ok {
+		return fmt.Errorf("unable to cast txResult, %s", data)
+	}
+
+	gasPrices, err := methods.GetGasPricesByTxResults(txResults)
+	if err != nil {
+		return err
+	}
+
+	return b.conn.WriteData(spec.NewJSONSubscribeResponse(id, gasPrices))
+}

--- a/serve/filters/subscription/gas_test.go
+++ b/serve/filters/subscription/gas_test.go
@@ -1,0 +1,45 @@
+package subscription
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/tx-indexer/internal/mock"
+	"github.com/gnolang/tx-indexer/serve/methods"
+	"github.com/gnolang/tx-indexer/serve/spec"
+)
+
+func TestGasPriceSubscription_WriteResponse(t *testing.T) {
+	t.Parallel()
+
+	var (
+		capturedWrite any
+
+		mockTxResults = []*types.TxResult{}
+		mockGasPrices = []*methods.GasPrice{}
+	)
+
+	expectedGasPricesResponse := spec.NewJSONSubscribeResponse("", mockGasPrices)
+
+	mockConn := &mock.Conn{
+		WriteDataFn: func(data any) error {
+			capturedWrite = data
+
+			return nil
+		},
+	}
+
+	// Create the block subscription
+	gasPriceSubscription := NewGasPriceSubscription(mockConn)
+
+	// Write the response
+	require.NoError(t, gasPriceSubscription.WriteResponse("", mockTxResults))
+
+	// Make sure the captured data matches
+	require.NotNil(t, capturedWrite)
+
+	assert.Equal(t, expectedGasPricesResponse, capturedWrite)
+}

--- a/serve/filters/subscription/gas_test.go
+++ b/serve/filters/subscription/gas_test.go
@@ -18,7 +18,7 @@ func TestGasPriceSubscription_WriteResponse(t *testing.T) {
 	var (
 		capturedWrite any
 
-		mockTxResults = []*types.TxResult{}
+		mockBlock     = &types.Block{}
 		mockGasPrices = []*methods.GasPrice{}
 	)
 
@@ -36,7 +36,7 @@ func TestGasPriceSubscription_WriteResponse(t *testing.T) {
 	gasPriceSubscription := NewGasPriceSubscription(mockConn)
 
 	// Write the response
-	require.NoError(t, gasPriceSubscription.WriteResponse("", mockTxResults))
+	require.NoError(t, gasPriceSubscription.WriteResponse("", mockBlock))
 
 	// Make sure the captured data matches
 	require.NotNil(t, capturedWrite)

--- a/serve/handlers/gas/gas.go
+++ b/serve/handlers/gas/gas.go
@@ -2,7 +2,6 @@ package gas
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
@@ -58,11 +57,9 @@ func (h *Handler) GetGasPriceHandler(
 func (h *Handler) getGasPriceBy(fromBlockNum, toBlockNum uint64) ([]*methods.GasPrice, error) {
 	it, err := h.
 		storage.
-		TxIterator(
+		BlockIterator(
 			fromBlockNum,
 			toBlockNum,
-			0,
-			math.MaxUint32,
 		)
 	if err != nil {
 		return nil, gqlerror.Wrap(err)
@@ -70,22 +67,22 @@ func (h *Handler) getGasPriceBy(fromBlockNum, toBlockNum uint64) ([]*methods.Gas
 
 	defer it.Close()
 
-	txs := make([]*types.TxResult, 0)
+	blocks := make([]*types.Block, 0)
 
 	for {
 		if !it.Next() {
 			break
 		}
 
-		tx, itErr := it.Value()
+		block, itErr := it.Value()
 		if itErr != nil {
 			return nil, err
 		}
 
-		txs = append(txs, tx)
+		blocks = append(blocks, block)
 	}
 
-	gasPrices, err := methods.GetGasPricesByTxResults(txs)
+	gasPrices, err := methods.GetGasPricesByBlocks(blocks)
 	if err != nil {
 		return nil, err
 	}

--- a/serve/handlers/gas/gas.go
+++ b/serve/handlers/gas/gas.go
@@ -90,10 +90,6 @@ func (h *Handler) getGasPriceBy(fromBlockNum, toBlockNum uint64) ([]*methods.Gas
 	return gasPrices, nil
 }
 
-func toUint64(data any) (uint64, error) {
-	return strconv.ParseUint(fmt.Sprintf("%v", data), 10, 64)
-}
-
 func initializeDefaultBlockRangeByHeight(latestHeight uint64) (uint64, uint64) {
 	toBlockNum := latestHeight
 
@@ -107,12 +103,12 @@ func initializeDefaultBlockRangeByHeight(latestHeight uint64) (uint64, uint64) {
 }
 
 func parseBlockRangeByParams(params []any) (uint64, uint64) {
-	fromBlockNum, err := toUint64(params[0])
+	fromBlockNum, err := strconv.ParseUint(fmt.Sprintf("%v", params[0]), 10, 64)
 	if err != nil {
 		fromBlockNum = 0
 	}
 
-	toBlockNum, err := toUint64(params[1])
+	toBlockNum, err := strconv.ParseUint(fmt.Sprintf("%v", params[1]), 10, 64)
 	if err != nil {
 		toBlockNum = 0
 	}

--- a/serve/handlers/gas/gas_test.go
+++ b/serve/handlers/gas/gas_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetTx_InvalidParams(t *testing.T) {
+func TestGetGasPriceHandler_InvalidParams(t *testing.T) {
 	t.Parallel()
 
 	testTable := []struct {
@@ -35,7 +35,6 @@ func TestGetTx_InvalidParams(t *testing.T) {
 			assert.Nil(t, response)
 
 			require.NotNil(t, err)
-
 			assert.Equal(t, spec.InvalidParamsErrorCode, err.Code)
 		})
 	}

--- a/serve/handlers/gas/gas_test.go
+++ b/serve/handlers/gas/gas_test.go
@@ -1,0 +1,42 @@
+package gas
+
+import (
+	"testing"
+
+	"github.com/gnolang/tx-indexer/serve/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTx_InvalidParams(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		name   string
+		params []any
+	}{
+		{
+			"invalid param length",
+			[]any{1},
+		},
+		{
+			"invalid param type",
+			[]any{"totally invalid param type"},
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewHandler(&mockStorage{})
+
+			response, err := h.GetGasPriceHandler(nil, testCase.params)
+			assert.Nil(t, response)
+
+			require.NotNil(t, err)
+
+			assert.Equal(t, spec.InvalidParamsErrorCode, err.Code)
+		})
+	}
+}

--- a/serve/handlers/gas/mocks_test.go
+++ b/serve/handlers/gas/mocks_test.go
@@ -7,11 +7,11 @@ import (
 
 type getLatestHeight func() (uint64, error)
 
-type txIterator func(uint64, uint64, uint32, uint32) (storage.Iterator[*types.TxResult], error)
+type blockIterator func(uint64, uint64) (storage.Iterator[*types.Block], error)
 
 type mockStorage struct {
 	getLatestHeightFn getLatestHeight
-	txIteratorFn      txIterator
+	blockIteratorFn   blockIterator
 }
 
 func (m *mockStorage) GetLatestHeight() (uint64, error) {
@@ -22,14 +22,12 @@ func (m *mockStorage) GetLatestHeight() (uint64, error) {
 	return 0, nil
 }
 
-func (m *mockStorage) TxIterator(
+func (m *mockStorage) BlockIterator(
 	fromBlockNum,
 	toBlockNum uint64,
-	fromTxIndex,
-	toTxIndex uint32,
-) (storage.Iterator[*types.TxResult], error) {
-	if m.txIteratorFn != nil {
-		return m.txIteratorFn(fromBlockNum, toBlockNum, fromTxIndex, toTxIndex)
+) (storage.Iterator[*types.Block], error) {
+	if m.blockIteratorFn != nil {
+		return m.blockIteratorFn(fromBlockNum, toBlockNum)
 	}
 
 	return nil, nil

--- a/serve/handlers/gas/mocks_test.go
+++ b/serve/handlers/gas/mocks_test.go
@@ -1,0 +1,36 @@
+package gas
+
+import (
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/tx-indexer/storage"
+)
+
+type getLatestHeight func() (uint64, error)
+
+type txIterator func(uint64, uint64, uint32, uint32) (storage.Iterator[*types.TxResult], error)
+
+type mockStorage struct {
+	getLatestHeightFn getLatestHeight
+	txIteratorFn      txIterator
+}
+
+func (m *mockStorage) GetLatestHeight() (uint64, error) {
+	if m.getLatestHeightFn != nil {
+		return m.getLatestHeightFn()
+	}
+
+	return 0, nil
+}
+
+func (m *mockStorage) TxIterator(
+	fromBlockNum,
+	toBlockNum uint64,
+	fromTxIndex,
+	toTxIndex uint32,
+) (storage.Iterator[*types.TxResult], error) {
+	if m.txIteratorFn != nil {
+		return m.txIteratorFn(fromBlockNum, toBlockNum, fromTxIndex, toTxIndex)
+	}
+
+	return nil, nil
+}

--- a/serve/handlers/gas/types.go
+++ b/serve/handlers/gas/types.go
@@ -6,14 +6,9 @@ import (
 )
 
 type Storage interface {
-	// GetTx returns specified tx from permanent storage
+	// GetLatestHeight returns the latest block height from the storage
 	GetLatestHeight() (uint64, error)
 
-	// GetTxByHash fetches the tx using the transaction hash
-	TxIterator(
-		fromBlockNum,
-		toBlockNum uint64,
-		fromTxIndex,
-		toTxIndex uint32,
-	) (storage.Iterator[*types.TxResult], error)
+	// BlockIterator iterates over Blocks, limiting the results to be between the provided block numbers
+	BlockIterator(fromBlockNum, toBlockNum uint64) (storage.Iterator[*types.Block], error)
 }

--- a/serve/handlers/gas/types.go
+++ b/serve/handlers/gas/types.go
@@ -1,0 +1,19 @@
+package gas
+
+import (
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/tx-indexer/storage"
+)
+
+type Storage interface {
+	// GetTx returns specified tx from permanent storage
+	GetLatestHeight() (uint64, error)
+
+	// GetTxByHash fetches the tx using the transaction hash
+	TxIterator(
+		fromBlockNum,
+		toBlockNum uint64,
+		fromTxIndex,
+		toTxIndex uint32,
+	) (storage.Iterator[*types.TxResult], error)
+}

--- a/serve/handlers/subs/subs.go
+++ b/serve/handlers/subs/subs.go
@@ -136,6 +136,8 @@ func (h *Handler) subscribe(connID, eventType string) (string, error) {
 		return h.filterManager.NewBlockSubscription(conn), nil
 	case subscription.NewTransactionsEvent:
 		return h.filterManager.NewTransactionSubscription(conn), nil
+	case subscription.NewGasPriceEvent:
+		return h.filterManager.NewGasPriceSubscription(conn), nil
 	default:
 		return "", fmt.Errorf("invalid event type: %s", eventType)
 	}

--- a/serve/jsonrpc.go
+++ b/serve/jsonrpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gnolang/tx-indexer/serve/conns/wsconn"
 	"github.com/gnolang/tx-indexer/serve/filters"
 	"github.com/gnolang/tx-indexer/serve/handlers/block"
+	"github.com/gnolang/tx-indexer/serve/handlers/gas"
 	"github.com/gnolang/tx-indexer/serve/handlers/subs"
 	"github.com/gnolang/tx-indexer/serve/handlers/tx"
 	"github.com/gnolang/tx-indexer/serve/metadata"
@@ -124,6 +125,16 @@ func (j *JSONRPC) RegisterTxEndpoints(db tx.Storage) {
 	j.RegisterHandler(
 		"getTxResultByHash",
 		txHandler.GetTxByHashHandler,
+	)
+}
+
+// RegisterGasPriceEndpoints registers the gas price endpoints
+func (j *JSONRPC) RegisterGasEndpoints(db gas.Storage) {
+	gasPriceHandler := gas.NewHandler(db)
+
+	j.RegisterHandler(
+		"getGasPrice",
+		gasPriceHandler.GetGasPriceHandler,
 	)
 }
 

--- a/serve/methods/gas.go
+++ b/serve/methods/gas.go
@@ -68,7 +68,7 @@ func calculateGasFeePerBlock(block *types.Block) map[string]*gasFeeTotalInfo {
 }
 
 // calculateGasFee merges the gas fee statistics from a block into the global statistics.
-func calculateGasFee(currentInfo *gasFeeTotalInfo, blockInfo *gasFeeTotalInfo) *gasFeeTotalInfo {
+func calculateGasFee(currentInfo, blockInfo *gasFeeTotalInfo) *gasFeeTotalInfo {
 	if currentInfo == nil {
 		currentInfo = &gasFeeTotalInfo{}
 	}
@@ -107,6 +107,7 @@ func min(current, newValue int64) int64 {
 	if current == 0 || newValue < current {
 		return newValue
 	}
+
 	return current
 }
 
@@ -115,5 +116,6 @@ func max(current, newValue int64) int64 {
 	if newValue > current {
 		return newValue
 	}
+
 	return current
 }

--- a/serve/methods/gas.go
+++ b/serve/methods/gas.go
@@ -58,7 +58,7 @@ func calculateGasFeePerBlock(block *types.Block) map[string]*gasFeeTotalInfo {
 			gasFeeInfo[denom] = info
 		}
 
-		info.Low = min(info.Low, amount)
+		info.Low = minInt64WithDefault(info.Low, amount)
 		info.High = max(info.High, amount)
 		info.TotalAmount += amount
 		info.TotalCount++
@@ -73,7 +73,7 @@ func calculateGasFee(currentInfo, blockInfo *gasFeeTotalInfo) *gasFeeTotalInfo {
 		currentInfo = &gasFeeTotalInfo{}
 	}
 
-	currentInfo.Low = min(currentInfo.Low, blockInfo.Low)
+	currentInfo.Low = minInt64WithDefault(currentInfo.Low, blockInfo.Low)
 	currentInfo.High = max(currentInfo.High, blockInfo.High)
 	currentInfo.TotalAmount += blockInfo.TotalAmount / blockInfo.TotalCount
 	currentInfo.TotalCount++
@@ -103,17 +103,8 @@ func calculateGasPrices(gasFeeInfoMap map[string]*gasFeeTotalInfo) []*GasPrice {
 
 // min calculates the smaller of two values, or returns the new value
 // if the current value is uninitialized (0).
-func min(current, newValue int64) int64 {
+func minInt64WithDefault(current, newValue int64) int64 {
 	if current == 0 || newValue < current {
-		return newValue
-	}
-
-	return current
-}
-
-// max calculates the larger of two values.
-func max(current, newValue int64) int64 {
-	if newValue > current {
 		return newValue
 	}
 

--- a/serve/methods/gas.go
+++ b/serve/methods/gas.go
@@ -67,7 +67,7 @@ func calculateGasFeePerBlock(block *types.Block) map[string]*gasFeeTotalInfo {
 			gasFeeInfo[denom] = info
 		}
 
-		info.Low = minInt64WithDefault(info.Low, amount)
+		info.Low = minWithDefault(info.Low, amount)
 		info.High = max(info.High, amount)
 		info.TotalAmount += amount
 		info.TotalCount++
@@ -82,7 +82,7 @@ func modifyAggregatedInfo(currentInfo, blockInfo *gasFeeTotalInfo) error {
 		return fmt.Errorf("not initialized aggregated data")
 	}
 
-	currentInfo.Low = minInt64WithDefault(currentInfo.Low, blockInfo.Low)
+	currentInfo.Low = minWithDefault(currentInfo.Low, blockInfo.Low)
 	currentInfo.High = max(currentInfo.High, blockInfo.High)
 	currentInfo.TotalAmount += blockInfo.TotalAmount / blockInfo.TotalCount
 	currentInfo.TotalCount++
@@ -112,10 +112,10 @@ func calculateGasPrices(gasFeeInfoMap map[string]*gasFeeTotalInfo) []*GasPrice {
 
 // min calculates the smaller of two values, or returns the new value
 // if the current value is uninitialized (0).
-func minInt64WithDefault(current, newValue int64) int64 {
-	if current == 0 || newValue < current {
+func minWithDefault(current, newValue int64) int64 {
+	if current <= 0 {
 		return newValue
 	}
 
-	return current
+	return min(current, newValue)
 }

--- a/serve/methods/gas.go
+++ b/serve/methods/gas.go
@@ -1,0 +1,62 @@
+package methods
+
+import (
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+type gasFeeTotalInfo struct {
+	Low         int64
+	High        int64
+	TotalAmount int64
+	TotalCount  int64
+}
+
+func GetGasPricesByTxResults(txs []*types.TxResult) ([]*GasPrice, error) {
+	gasFeeInfoMap := make(map[string]*gasFeeTotalInfo)
+
+	for _, t := range txs {
+		var stdTx std.Tx
+		if err := amino.Unmarshal(t.Tx, &stdTx); err != nil {
+			continue
+		}
+
+		gasFeeDenom := stdTx.Fee.GasFee.Denom
+		gasFeeAmount := stdTx.Fee.GasFee.Amount
+
+		if _, exists := gasFeeInfoMap[gasFeeDenom]; !exists {
+			gasFeeInfoMap[gasFeeDenom] = &gasFeeTotalInfo{}
+		}
+
+		if gasFeeInfoMap[gasFeeDenom].Low == 0 || gasFeeInfoMap[gasFeeDenom].Low > gasFeeAmount {
+			gasFeeInfoMap[gasFeeDenom].Low = gasFeeAmount
+		}
+
+		if gasFeeInfoMap[gasFeeDenom].High == 0 || gasFeeInfoMap[gasFeeDenom].High < gasFeeAmount {
+			gasFeeInfoMap[gasFeeDenom].High = gasFeeAmount
+		}
+
+		gasFeeInfoMap[gasFeeDenom].TotalAmount += gasFeeAmount
+		gasFeeInfoMap[gasFeeDenom].TotalCount++
+	}
+
+	gasPrices := make([]*GasPrice, 0)
+
+	for denom, gasFeeInfo := range gasFeeInfoMap {
+		if gasFeeInfo.TotalCount == 0 {
+			continue
+		}
+
+		average := gasFeeInfo.TotalAmount / gasFeeInfo.TotalCount
+
+		gasPrices = append(gasPrices, &GasPrice{
+			High:    gasFeeInfo.High,
+			Low:     gasFeeInfo.Low,
+			Average: average,
+			Denom:   denom,
+		})
+	}
+
+	return gasPrices, nil
+}

--- a/serve/methods/gas.go
+++ b/serve/methods/gas.go
@@ -13,50 +13,107 @@ type gasFeeTotalInfo struct {
 	TotalCount  int64
 }
 
-func GetGasPricesByTxResults(txs []*types.TxResult) ([]*GasPrice, error) {
+// GetGasPricesByBlock calculates the gas price statistics (low, high, average)
+// for a single block.
+func GetGasPricesByBlock(block *types.Block) ([]*GasPrice, error) {
+	blocks := []*types.Block{block}
+
+	return GetGasPricesByBlocks(blocks)
+}
+
+// GetGasPricesByBlocks calculates the gas price statistics (low, high, average)
+// for multiple blocks.
+func GetGasPricesByBlocks(blocks []*types.Block) ([]*GasPrice, error) {
 	gasFeeInfoMap := make(map[string]*gasFeeTotalInfo)
 
-	for _, t := range txs {
-		var stdTx std.Tx
-		if err := amino.Unmarshal(t.Tx, &stdTx); err != nil {
-			continue
+	for _, block := range blocks {
+		blockGasFeeInfo := calculateGasFeePerBlock(block)
+
+		for denom, gasFeeInfo := range blockGasFeeInfo {
+			currentGasFeeInfo := gasFeeInfoMap[denom]
+			gasFeeInfoMap[denom] = calculateGasFee(currentGasFeeInfo, gasFeeInfo)
 		}
-
-		gasFeeDenom := stdTx.Fee.GasFee.Denom
-		gasFeeAmount := stdTx.Fee.GasFee.Amount
-
-		if _, exists := gasFeeInfoMap[gasFeeDenom]; !exists {
-			gasFeeInfoMap[gasFeeDenom] = &gasFeeTotalInfo{}
-		}
-
-		if gasFeeInfoMap[gasFeeDenom].Low == 0 || gasFeeInfoMap[gasFeeDenom].Low > gasFeeAmount {
-			gasFeeInfoMap[gasFeeDenom].Low = gasFeeAmount
-		}
-
-		if gasFeeInfoMap[gasFeeDenom].High == 0 || gasFeeInfoMap[gasFeeDenom].High < gasFeeAmount {
-			gasFeeInfoMap[gasFeeDenom].High = gasFeeAmount
-		}
-
-		gasFeeInfoMap[gasFeeDenom].TotalAmount += gasFeeAmount
-		gasFeeInfoMap[gasFeeDenom].TotalCount++
 	}
 
-	gasPrices := make([]*GasPrice, 0)
+	return calculateGasPrices(gasFeeInfoMap), nil
+}
 
-	for denom, gasFeeInfo := range gasFeeInfoMap {
-		if gasFeeInfo.TotalCount == 0 {
+// calculateGasFeePerBlock processes all transactions in a single block to compute
+// gas fee statistics (low, high, total amount, total count) for each gas fee denomination.
+func calculateGasFeePerBlock(block *types.Block) map[string]*gasFeeTotalInfo {
+	gasFeeInfo := make(map[string]*gasFeeTotalInfo)
+
+	for _, t := range block.Txs {
+		var stdTx std.Tx
+		if err := amino.Unmarshal(t, &stdTx); err != nil {
 			continue
 		}
 
-		average := gasFeeInfo.TotalAmount / gasFeeInfo.TotalCount
+		denom := stdTx.Fee.GasFee.Denom
+		amount := stdTx.Fee.GasFee.Amount
+
+		info := gasFeeInfo[denom]
+		if info == nil {
+			info = &gasFeeTotalInfo{}
+			gasFeeInfo[denom] = info
+		}
+
+		info.Low = min(info.Low, amount)
+		info.High = max(info.High, amount)
+		info.TotalAmount += amount
+		info.TotalCount++
+	}
+
+	return gasFeeInfo
+}
+
+// calculateGasFee merges the gas fee statistics from a block into the global statistics.
+func calculateGasFee(currentInfo *gasFeeTotalInfo, blockInfo *gasFeeTotalInfo) *gasFeeTotalInfo {
+	if currentInfo == nil {
+		currentInfo = &gasFeeTotalInfo{}
+	}
+
+	currentInfo.Low = min(currentInfo.Low, blockInfo.Low)
+	currentInfo.High = max(currentInfo.High, blockInfo.High)
+	currentInfo.TotalAmount += blockInfo.TotalAmount / blockInfo.TotalCount
+	currentInfo.TotalCount++
+
+	return currentInfo
+}
+
+// calculateGasPrices generates the final gas price statistics (low, high, average)
+func calculateGasPrices(gasFeeInfoMap map[string]*gasFeeTotalInfo) []*GasPrice {
+	gasPrices := make([]*GasPrice, 0, len(gasFeeInfoMap))
+
+	for denom, info := range gasFeeInfoMap {
+		if info.TotalCount == 0 {
+			continue
+		}
 
 		gasPrices = append(gasPrices, &GasPrice{
-			High:    gasFeeInfo.High,
-			Low:     gasFeeInfo.Low,
-			Average: average,
+			High:    info.High,
+			Low:     info.Low,
+			Average: info.TotalAmount / info.TotalCount,
 			Denom:   denom,
 		})
 	}
 
-	return gasPrices, nil
+	return gasPrices
+}
+
+// min calculates the smaller of two values, or returns the new value
+// if the current value is uninitialized (0).
+func min(current, newValue int64) int64 {
+	if current == 0 || newValue < current {
+		return newValue
+	}
+	return current
+}
+
+// max calculates the larger of two values.
+func max(current, newValue int64) int64 {
+	if newValue > current {
+		return newValue
+	}
+	return current
 }

--- a/serve/methods/gas_test.go
+++ b/serve/methods/gas_test.go
@@ -1,0 +1,124 @@
+package methods
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGasPricesByTxResults_EmptyTransactions(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		name string
+		txs  []*types.TxResult
+	}{
+		{
+			"txs is nil",
+			nil,
+		},
+		{
+			"tx is empty",
+			[]*types.TxResult{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			response, err := GetGasPricesByTxResults(testCase.txs)
+
+			assert.Nil(t, err)
+
+			require.NotNil(t, response)
+
+			assert.Equal(t, len(response), 0)
+		})
+	}
+}
+
+func TestGetGasPricesByTxResults_Transactions(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		name    string
+		txs     []*types.TxResult
+		results []GasPrice
+	}{
+		{
+			"single transaction",
+			[]*types.TxResult{
+				makeTxResultHasGasFee(1, "ugnot"),
+			},
+			[]GasPrice{
+				{
+					Denom:   "ugnot",
+					High:    1,
+					Average: 1,
+					Low:     1,
+				},
+			},
+		},
+		{
+			"variable amount",
+			[]*types.TxResult{
+				makeTxResultHasGasFee(1, "ugnot"),
+				makeTxResultHasGasFee(2, "ugnot"),
+				makeTxResultHasGasFee(3, "ugnot"),
+				makeTxResultHasGasFee(4, "ugnot"),
+			},
+			[]GasPrice{
+				{
+					Denom:   "ugnot",
+					High:    4,
+					Average: 2,
+					Low:     1,
+				},
+			},
+		},
+		{
+			"variable amounts and coins",
+			[]*types.TxResult{
+				makeTxResultHasGasFee(1, "ugnot"),
+				makeTxResultHasGasFee(2, "ugnot"),
+				makeTxResultHasGasFee(3, "uatom"),
+				makeTxResultHasGasFee(4, "uatom"),
+			},
+			[]GasPrice{
+				{
+					Denom:   "ugnot",
+					High:    2,
+					Average: 1,
+					Low:     1,
+				},
+				{
+					Denom:   "uatom",
+					High:    4,
+					Average: 3,
+					Low:     3,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			response, err := GetGasPricesByTxResults(testCase.txs)
+
+			assert.Nil(t, err)
+			require.NotNil(t, response)
+
+			for index, responseItem := range response {
+				assert.Equal(t, responseItem.Denom, testCase.results[index].Denom)
+				assert.Equal(t, responseItem.High, testCase.results[index].High)
+				assert.Equal(t, responseItem.Average, testCase.results[index].Average)
+				assert.Equal(t, responseItem.Low, testCase.results[index].Low)
+			}
+		})
+	}
+}

--- a/serve/methods/gas_test.go
+++ b/serve/methods/gas_test.go
@@ -51,7 +51,7 @@ func TestGetGasPricesByTxResults_Transactions(t *testing.T) {
 		{
 			"single transaction",
 			[]*types.TxResult{
-				makeTxResultHasGasFee(1, "ugnot"),
+				makeTxResultWithGasFee(1, "ugnot"),
 			},
 			[]GasPrice{
 				{
@@ -65,10 +65,10 @@ func TestGetGasPricesByTxResults_Transactions(t *testing.T) {
 		{
 			"variable amount",
 			[]*types.TxResult{
-				makeTxResultHasGasFee(1, "ugnot"),
-				makeTxResultHasGasFee(2, "ugnot"),
-				makeTxResultHasGasFee(3, "ugnot"),
-				makeTxResultHasGasFee(4, "ugnot"),
+				makeTxResultWithGasFee(1, "ugnot"),
+				makeTxResultWithGasFee(2, "ugnot"),
+				makeTxResultWithGasFee(3, "ugnot"),
+				makeTxResultWithGasFee(4, "ugnot"),
 			},
 			[]GasPrice{
 				{
@@ -82,10 +82,10 @@ func TestGetGasPricesByTxResults_Transactions(t *testing.T) {
 		{
 			"variable amounts and coins",
 			[]*types.TxResult{
-				makeTxResultHasGasFee(1, "ugnot"),
-				makeTxResultHasGasFee(2, "ugnot"),
-				makeTxResultHasGasFee(3, "uatom"),
-				makeTxResultHasGasFee(4, "uatom"),
+				makeTxResultWithGasFee(1, "ugnot"),
+				makeTxResultWithGasFee(2, "ugnot"),
+				makeTxResultWithGasFee(3, "uatom"),
+				makeTxResultWithGasFee(4, "uatom"),
 			},
 			[]GasPrice{
 				{

--- a/serve/methods/gas_test.go
+++ b/serve/methods/gas_test.go
@@ -117,14 +117,16 @@ func TestGetGasPricesByTxResults_Transactions(t *testing.T) {
 
 			for _, responseItem := range response {
 				for _, testCaseResult := range testCase.results {
-					if responseItem.Denom == testCaseResult.Denom {
-						assert.Equal(t, responseItem.Denom, testCaseResult.Denom)
-						assert.Equal(t, responseItem.High, testCaseResult.High)
-						assert.Equal(t, responseItem.Average, testCaseResult.Average)
-						assert.Equal(t, responseItem.Low, testCaseResult.Low)
-
-						count++
+					if responseItem.Denom != testCaseResult.Denom {
+						continue
 					}
+
+					assert.Equal(t, responseItem.Denom, testCaseResult.Denom)
+					assert.Equal(t, responseItem.High, testCaseResult.High)
+					assert.Equal(t, responseItem.Average, testCaseResult.Average)
+					assert.Equal(t, responseItem.Low, testCaseResult.Low)
+
+					count++
 				}
 			}
 

--- a/serve/methods/gas_test.go
+++ b/serve/methods/gas_test.go
@@ -113,12 +113,22 @@ func TestGetGasPricesByTxResults_Transactions(t *testing.T) {
 			assert.Nil(t, err)
 			require.NotNil(t, response)
 
-			for index, responseItem := range response {
-				assert.Equal(t, responseItem.Denom, testCase.results[index].Denom)
-				assert.Equal(t, responseItem.High, testCase.results[index].High)
-				assert.Equal(t, responseItem.Average, testCase.results[index].Average)
-				assert.Equal(t, responseItem.Low, testCase.results[index].Low)
+			count := 0
+
+			for _, responseItem := range response {
+				for _, testCaseResult := range testCase.results {
+					if responseItem.Denom == testCaseResult.Denom {
+						assert.Equal(t, responseItem.Denom, testCaseResult.Denom)
+						assert.Equal(t, responseItem.High, testCaseResult.High)
+						assert.Equal(t, responseItem.Average, testCaseResult.Average)
+						assert.Equal(t, responseItem.Low, testCaseResult.Low)
+
+						count++
+					}
+				}
 			}
+
+			assert.Equal(t, count, len(testCase.results))
 		})
 	}
 }

--- a/serve/methods/mocks_test.go
+++ b/serve/methods/mocks_test.go
@@ -6,7 +6,18 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
-func makeTxResultWithGasFee(gasFeeAmount int64, gasFeeDenom string) *types.TxResult {
+func makeBlockWithTxs(height int64, txs []types.Tx) *types.Block {
+	return &types.Block{
+		Header: types.Header{
+			Height: height,
+		},
+		Data: types.Data{
+			Txs: txs,
+		},
+	}
+}
+
+func makeTxResultWithGasFee(gasFeeAmount int64, gasFeeDenom string) types.Tx {
 	tx := std.Tx{
 		Fee: std.Fee{
 			GasFee: std.Coin{
@@ -16,7 +27,5 @@ func makeTxResultWithGasFee(gasFeeAmount int64, gasFeeDenom string) *types.TxRes
 		},
 	}
 
-	return &types.TxResult{
-		Tx: amino.MustMarshal(tx),
-	}
+	return amino.MustMarshal(tx)
 }

--- a/serve/methods/mocks_test.go
+++ b/serve/methods/mocks_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
-func makeTxResultHasGasFee(gasFeeAmount int64, gasFeeDenom string) *types.TxResult {
+func makeTxResultWithGasFee(gasFeeAmount int64, gasFeeDenom string) *types.TxResult {
 	tx := std.Tx{
 		Fee: std.Fee{
 			GasFee: std.Coin{

--- a/serve/methods/mocks_test.go
+++ b/serve/methods/mocks_test.go
@@ -1,0 +1,22 @@
+package methods
+
+import (
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/std"
+)
+
+func makeTxResultHasGasFee(gasFeeAmount int64, gasFeeDenom string) *types.TxResult {
+	tx := std.Tx{
+		Fee: std.Fee{
+			GasFee: std.Coin{
+				Denom:  gasFeeDenom,
+				Amount: gasFeeAmount,
+			},
+		},
+	}
+
+	return &types.TxResult{
+		Tx: amino.MustMarshal(tx),
+	}
+}

--- a/serve/methods/types.go
+++ b/serve/methods/types.go
@@ -1,0 +1,8 @@
+package methods
+
+type GasPrice struct {
+	Denom   string `json:"denom"`
+	Low     int64  `json:"low"`
+	Average int64  `json:"average"`
+	High    int64  `json:"high"`
+}


### PR DESCRIPTION
## Descriptions

Add an RPC endpoints to get the transaction's gas fee based gas price.

The price of gas provides `low`, `average`, and `high` values for each denomination of the coin.

### Gas Price Endpoints

#### `getGasPrice`
Retrieve gas information by coin for a block range.

- **Params**: If empty, it defaults to a range of 1,000 blocks from the latest block.
    - from block height (`number`)
    - to block height (`number`)
- **Response**: List results for gas prices with `low`, `average`, `high`, and `denom`.

Example request:
```json
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "getGasPrice",
  "params": [100, 200] // If parameters are empty, the default is latest 1,000 blocks
}
```

Example response:
```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": [
        {
            "low": 40000,
            "average": 50000,
            "high": 70000,
            "denom": "ugnot"
        }
    ]
}
```

#### `subscribe`
- `newGasPrice` - fires a notification whenever a block with a new transaction is added to the chain.

Example request (over WS):

```json
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "subscribe",
  "params": [
    "newGasPrice"
  ]
}
```

Example response when a `newGasPrice` event happens (over WS):
```json
{
    "params": {
        "result": [
            {
                "low": 70000,
                "average": 70000,
                "high": 70000,
                "denom": "ugnot"
            }
        ],
        "subscription": "eb654246-a1c4-4ef2-9d99-42e1308ee68f"
    },
    "jsonrpc": "2.0",
    "method": "subscription"
}
```

---
### Related Issue
- https://github.com/gnolang/gno/issues/1826
- https://github.com/gnolang/gno/pull/3207