### PR TITLE
fix: calculate gas price info

### DIFF
--- a/serve/filters/manager.go
+++ b/serve/filters/manager.go
@@ -129,8 +129,8 @@ func (f *Manager) subscribeToEvents() {
 					f.subscriptions.sendEvent(filterSubscription.NewHeadsEvent, newBlock.Block)
 
 					// Send an event to the `newGasPrice` subscription when creating a block with transactions
-					if len(newBlock.Block.Txs) > 0 {
-						f.subscriptions.sendEvent(filterSubscription.NewGasPriceEvent, newBlock.Block)
+					if len(newBlock.Results) > 0 {
+						f.subscriptions.sendEvent(filterSubscription.NewGasPriceEvent, newBlock.Results)
 					}
 
 					for _, txResult := range newBlock.Results {

--- a/serve/filters/subscription/gas.go
+++ b/serve/filters/subscription/gas.go
@@ -31,12 +31,12 @@ func (b *GasPriceSubscription) GetType() events.Type {
 }
 
 func (b *GasPriceSubscription) WriteResponse(id string, data any) error {
-	block, ok := data.(*types.Block)
+	txResults, ok := data.([]*types.TxResult)
 	if !ok {
 		return fmt.Errorf("unable to cast txResult, %s", data)
 	}
 
-	gasPrices, err := methods.GetGasPricesByBlock(block)
+	gasPrices, err := methods.GetGasPricesByTxResults(txResults)
 	if err != nil {
 		return err
 	}

--- a/serve/filters/subscription/gas_test.go
+++ b/serve/filters/subscription/gas_test.go
@@ -18,7 +18,7 @@ func TestGasPriceSubscription_WriteResponse(t *testing.T) {
 	var (
 		capturedWrite any
 
-		mockBlock     = &types.Block{}
+		mockTxResults = []*types.TxResult{}
 		mockGasPrices = []*methods.GasPrice{}
 	)
 
@@ -36,7 +36,7 @@ func TestGasPriceSubscription_WriteResponse(t *testing.T) {
 	gasPriceSubscription := NewGasPriceSubscription(mockConn)
 
 	// Write the response
-	require.NoError(t, gasPriceSubscription.WriteResponse("", mockBlock))
+	require.NoError(t, gasPriceSubscription.WriteResponse("", mockTxResults))
 
 	// Make sure the captured data matches
 	require.NotNil(t, capturedWrite)

--- a/serve/handlers/gas/mocks_test.go
+++ b/serve/handlers/gas/mocks_test.go
@@ -7,11 +7,11 @@ import (
 
 type getLatestHeight func() (uint64, error)
 
-type blockIterator func(uint64, uint64) (storage.Iterator[*types.Block], error)
+type txReverseIterator func(uint64, uint64, uint32, uint32) (storage.Iterator[*types.TxResult], error)
 
 type mockStorage struct {
-	getLatestHeightFn getLatestHeight
-	blockIteratorFn   blockIterator
+	getLatestHeightFn   getLatestHeight
+	txReverseIteratorFn txReverseIterator
 }
 
 func (m *mockStorage) GetLatestHeight() (uint64, error) {
@@ -22,12 +22,14 @@ func (m *mockStorage) GetLatestHeight() (uint64, error) {
 	return 0, nil
 }
 
-func (m *mockStorage) BlockIterator(
-	fromBlockNum,
-	toBlockNum uint64,
-) (storage.Iterator[*types.Block], error) {
-	if m.blockIteratorFn != nil {
-		return m.blockIteratorFn(fromBlockNum, toBlockNum)
+func (m *mockStorage) TxReverseIterator(
+	fromTxNum,
+	toTxNum uint64,
+	fromIndex,
+	toIndex uint32,
+) (storage.Iterator[*types.TxResult], error) {
+	if m.txReverseIteratorFn != nil {
+		return m.txReverseIteratorFn(fromTxNum, toTxNum, fromIndex, toIndex)
 	}
 
 	return nil, nil

--- a/serve/handlers/gas/types.go
+++ b/serve/handlers/gas/types.go
@@ -9,6 +9,12 @@ type Storage interface {
 	// GetLatestHeight returns the latest block height from the storage
 	GetLatestHeight() (uint64, error)
 
-	// BlockIterator iterates over Blocks, limiting the results to be between the provided block numbers
-	BlockIterator(fromBlockNum, toBlockNum uint64) (storage.Iterator[*types.Block], error)
+	// TxIterator iterates over transactions, limiting the results to be between the provided block numbers
+	// and transaction indexes
+	TxReverseIterator(
+		fromBlockNum,
+		toBlockNum uint64,
+		fromTxIndex,
+		toTxIndex uint32,
+	) (storage.Iterator[*types.TxResult], error)
 }

--- a/serve/methods/gas.go
+++ b/serve/methods/gas.go
@@ -9,57 +9,65 @@ import (
 )
 
 type gasFeeTotalInfo struct {
-	Low         int64
-	High        int64
-	TotalAmount int64
+	Low         float64
+	High        float64
+	TotalAmount float64
 	TotalCount  int64
 }
 
-// GetGasPricesByBlock calculates the gas price statistics (low, high, average)
-// for a single block.
-func GetGasPricesByBlock(block *types.Block) ([]*GasPrice, error) {
-	blocks := []*types.Block{block}
+// GetGasPricesByTxResult calculates the gas price statistics (low, high, average)
+// for a single txResult.
+func GetGasPricesByTxResult(txResult *types.TxResult) ([]*GasPrice, error) {
+	txResults := []*types.TxResult{txResult}
 
-	return GetGasPricesByBlocks(blocks)
+	return GetGasPricesByTxResults(txResults)
 }
 
-// GetGasPricesByBlocks calculates the gas price statistics (low, high, average)
-// for multiple blocks.
-func GetGasPricesByBlocks(blocks []*types.Block) ([]*GasPrice, error) {
+// GetGasPricesByTxResults calculates the gas price statistics (low, high, average)
+// for multiple txResults.
+func GetGasPricesByTxResults(txResults []*types.TxResult) ([]*GasPrice, error) {
 	gasFeeInfoMap := make(map[string]*gasFeeTotalInfo)
 
-	for _, block := range blocks {
-		blockGasFeeInfo := calculateGasFeePerBlock(block)
+	txResultGasFeeInfo := calculateGasFeePerTxResults(txResults)
 
-		for denom, gasFeeInfo := range blockGasFeeInfo {
-			_, exists := gasFeeInfoMap[denom]
-			if !exists {
-				gasFeeInfoMap[denom] = &gasFeeTotalInfo{}
-			}
+	for denom, gasFeeInfo := range txResultGasFeeInfo {
+		_, exists := gasFeeInfoMap[denom]
+		if !exists {
+			gasFeeInfoMap[denom] = &gasFeeTotalInfo{}
+		}
 
-			err := modifyAggregatedInfo(gasFeeInfoMap[denom], gasFeeInfo)
-			if err != nil {
-				return nil, err
-			}
+		err := modifyAggregatedInfo(gasFeeInfoMap[denom], gasFeeInfo)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	return calculateGasPrices(gasFeeInfoMap), nil
 }
 
-// calculateGasFeePerBlock processes all transactions in a single block to compute
+// calculateGasFeePerTxResult processes all transactions in a single txResult to compute
 // gas fee statistics (low, high, total amount, total count) for each gas fee denomination.
-func calculateGasFeePerBlock(block *types.Block) map[string]*gasFeeTotalInfo {
+func calculateGasFeePerTxResults(txResults []*types.TxResult) map[string]*gasFeeTotalInfo {
 	gasFeeInfo := make(map[string]*gasFeeTotalInfo)
 
-	for _, t := range block.Txs {
+	for _, t := range txResults {
+		if t.Response.IsErr() ||
+			t.Response.GasUsed == 0 ||
+			t.Height <= 0 {
+			continue
+		}
+
 		var stdTx std.Tx
-		if err := amino.Unmarshal(t, &stdTx); err != nil {
+		if err := amino.Unmarshal(t.Tx, &stdTx); err != nil {
 			continue
 		}
 
 		denom := stdTx.Fee.GasFee.Denom
-		amount := stdTx.Fee.GasFee.Amount
+		gasFeeAmount := stdTx.Fee.GasFee.Amount
+		GasUsedAmount := t.Response.GasUsed
+
+		// Calculate the gas price (gasFee / gasUsed)
+		gasPrice := float64(gasFeeAmount) / float64(GasUsedAmount)
 
 		info := gasFeeInfo[denom]
 		if info == nil {
@@ -67,24 +75,24 @@ func calculateGasFeePerBlock(block *types.Block) map[string]*gasFeeTotalInfo {
 			gasFeeInfo[denom] = info
 		}
 
-		info.Low = minWithDefault(info.Low, amount)
-		info.High = max(info.High, amount)
-		info.TotalAmount += amount
+		info.Low = minWithDefault(info.Low, gasPrice)
+		info.High = max(info.High, gasPrice)
+		info.TotalAmount += gasPrice
 		info.TotalCount++
 	}
 
 	return gasFeeInfo
 }
 
-// modifyAggregatedInfo updates the aggregated gas fee statistics by merging the block's statistics.
-func modifyAggregatedInfo(currentInfo, blockInfo *gasFeeTotalInfo) error {
+// modifyAggregatedInfo updates the aggregated gas fee statistics by merging the txResult's statistics.
+func modifyAggregatedInfo(currentInfo, txResultInfo *gasFeeTotalInfo) error {
 	if currentInfo == nil {
 		return fmt.Errorf("not initialized aggregated data")
 	}
 
-	currentInfo.Low = minWithDefault(currentInfo.Low, blockInfo.Low)
-	currentInfo.High = max(currentInfo.High, blockInfo.High)
-	currentInfo.TotalAmount += blockInfo.TotalAmount / blockInfo.TotalCount
+	currentInfo.Low = minWithDefault(currentInfo.Low, txResultInfo.Low)
+	currentInfo.High = max(currentInfo.High, txResultInfo.High)
+	currentInfo.TotalAmount += txResultInfo.TotalAmount / float64(txResultInfo.TotalCount)
 	currentInfo.TotalCount++
 
 	return nil
@@ -102,7 +110,7 @@ func calculateGasPrices(gasFeeInfoMap map[string]*gasFeeTotalInfo) []*GasPrice {
 		gasPrices = append(gasPrices, &GasPrice{
 			High:    info.High,
 			Low:     info.Low,
-			Average: info.TotalAmount / info.TotalCount,
+			Average: info.TotalAmount / float64(info.TotalCount),
 			Denom:   denom,
 		})
 	}
@@ -112,7 +120,7 @@ func calculateGasPrices(gasFeeInfoMap map[string]*gasFeeTotalInfo) []*GasPrice {
 
 // min calculates the smaller of two values, or returns the new value
 // if the current value is uninitialized (0).
-func minWithDefault(current, newValue int64) int64 {
+func minWithDefault(current, newValue float64) float64 {
 	if current <= 0 {
 		return newValue
 	}

--- a/serve/methods/gas_test.go
+++ b/serve/methods/gas_test.go
@@ -12,8 +12,8 @@ func TestGetGasPricesByBlocks_EmptyTransactions(t *testing.T) {
 	t.Parallel()
 
 	testTable := []struct {
-		name   string
-		blocks []*types.Block
+		name      string
+		txResults []*types.TxResult
 	}{
 		{
 			"txs is nil",
@@ -21,7 +21,7 @@ func TestGetGasPricesByBlocks_EmptyTransactions(t *testing.T) {
 		},
 		{
 			"tx is empty",
-			make([]*types.Block, 0),
+			make([]*types.TxResult, 0),
 		},
 	}
 
@@ -29,7 +29,7 @@ func TestGetGasPricesByBlocks_EmptyTransactions(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			response, err := GetGasPricesByBlocks(testCase.blocks)
+			response, err := GetGasPricesByTxResults(testCase.txResults)
 
 			assert.Nil(t, err)
 
@@ -44,18 +44,14 @@ func TestGetGasPricesByBlocks_Transactions(t *testing.T) {
 	t.Parallel()
 
 	testTable := []struct {
-		name    string
-		blocks  []*types.Block
-		results []GasPrice
+		name      string
+		txResults []*types.TxResult
+		results   []GasPrice
 	}{
 		{
 			"single transaction",
-			[]*types.Block{
-				makeBlockWithTxs(1,
-					[]types.Tx{
-						makeTxResultWithGasFee(1, "ugnot"),
-					},
-				),
+			[]*types.TxResult{
+				makeTxResult(1, 1, "ugnot", 1),
 			},
 			[]GasPrice{
 				{
@@ -68,74 +64,41 @@ func TestGetGasPricesByBlocks_Transactions(t *testing.T) {
 		},
 		{
 			"variable amount",
-			[]*types.Block{
-				makeBlockWithTxs(1,
-					[]types.Tx{
-						makeTxResultWithGasFee(1, "ugnot"),
-						makeTxResultWithGasFee(2, "ugnot"),
-						makeTxResultWithGasFee(3, "ugnot"),
-						makeTxResultWithGasFee(4, "ugnot"),
-					},
-				),
+			[]*types.TxResult{
+				makeTxResult(1, 1, "ugnot", 1),
+				makeTxResult(2, 1, "ugnot", 2),
+				makeTxResult(3, 1, "ugnot", 3),
+				makeTxResult(4, 1, "ugnot", 4),
 			},
 			[]GasPrice{
 				{
 					Denom:   "ugnot",
-					High:    4,
-					Average: 2,
-					Low:     1,
+					High:    1,
+					Average: 0.5208333333333333,
+					Low:     0.25,
 				},
 			},
 		},
 		{
 			"variable amounts and coins",
-			[]*types.Block{
-				makeBlockWithTxs(1,
-					[]types.Tx{
-						makeTxResultWithGasFee(1, "ugnot"),
-						makeTxResultWithGasFee(2, "ugnot"),
-						makeTxResultWithGasFee(3, "uatom"),
-						makeTxResultWithGasFee(4, "uatom"),
-					},
-				),
+			[]*types.TxResult{
+				makeTxResult(1, 1, "ugnot", 1),
+				makeTxResult(2, 1, "ugnot", 2),
+				makeTxResult(3, 3, "uatom", 3),
+				makeTxResult(4, 2, "uatom", 4),
 			},
 			[]GasPrice{
 				{
 					Denom:   "ugnot",
-					High:    2,
-					Average: 1,
-					Low:     1,
+					High:    1,
+					Average: 0.75,
+					Low:     0.5,
 				},
 				{
 					Denom:   "uatom",
-					High:    4,
-					Average: 3,
-					Low:     3,
-				},
-			},
-		},
-		{
-			"calculate the average value per block",
-			[]*types.Block{
-				makeBlockWithTxs(1,
-					[]types.Tx{
-						makeTxResultWithGasFee(1, "ugnot"),
-					},
-				),
-				makeBlockWithTxs(2,
-					[]types.Tx{
-						makeTxResultWithGasFee(10, "ugnot"),
-						makeTxResultWithGasFee(10, "ugnot"),
-						makeTxResultWithGasFee(10, "ugnot"),
-					},
-				),
-			},
-			[]GasPrice{
-				{
-					Denom:   "ugnot",
-					High:    10,
-					Average: 5,
-					Low:     1,
+					High:    1,
+					Average: 0.75,
+					Low:     0.5,
 				},
 			},
 		},
@@ -145,7 +108,7 @@ func TestGetGasPricesByBlocks_Transactions(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			response, err := GetGasPricesByBlocks(testCase.blocks)
+			response, err := GetGasPricesByTxResults(testCase.txResults)
 
 			assert.Nil(t, err)
 			require.NotNil(t, response)

--- a/serve/methods/mocks_test.go
+++ b/serve/methods/mocks_test.go
@@ -2,30 +2,30 @@ package methods
 
 import (
 	"github.com/gnolang/gno/tm2/pkg/amino"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
-func makeBlockWithTxs(height int64, txs []types.Tx) *types.Block {
-	return &types.Block{
-		Header: types.Header{
-			Height: height,
-		},
-		Data: types.Data{
-			Txs: txs,
-		},
-	}
-}
-
-func makeTxResultWithGasFee(gasFeeAmount int64, gasFeeDenom string) types.Tx {
-	tx := std.Tx{
-		Fee: std.Fee{
-			GasFee: std.Coin{
-				Denom:  gasFeeDenom,
-				Amount: gasFeeAmount,
+func makeTxResult(
+	height,
+	gasFeeAmount int64,
+	gasFeeDenom string,
+	gasUsed int64,
+) *types.TxResult {
+	return &types.TxResult{
+		Height: height,
+		Index:  0,
+		Tx: amino.MustMarshal(std.Tx{
+			Fee: std.Fee{
+				GasFee: std.Coin{
+					Denom:  gasFeeDenom,
+					Amount: gasFeeAmount,
+				},
 			},
+		}),
+		Response: abci.ResponseDeliverTx{
+			GasUsed: gasUsed,
 		},
 	}
-
-	return amino.MustMarshal(tx)
 }

--- a/serve/methods/types.go
+++ b/serve/methods/types.go
@@ -1,8 +1,8 @@
 package methods
 
 type GasPrice struct {
-	Denom   string `json:"denom"`
-	Low     int64  `json:"low"`
-	Average int64  `json:"average"`
-	High    int64  `json:"high"`
+	Denom   string  `json:"denom"`
+	Low     float64 `json:"low"`
+	Average float64 `json:"average"`
+	High    float64 `json:"high"`
 }


### PR DESCRIPTION
## Descriptions

This PR modifies the implementation introduced in [PR #120](https://github.com/gnolang/tx-indexer/pull/120).

### Current Behavior
When calling the `getGasPrice` method, it returns the High, Average, and Low values of `GasUsed`.

### Modifications
- Adjust the calculation so that the method returns the actual gas price instead of just gas usage.
- Compute the High, Average, and Low values of the gas price for block range.
- The gas price is now derived using the formula: 
    - Gas Price = GasFee / GasUsed