### PR TITLE
Fix: get correctly unfiltered transactions

### DIFF
--- a/storage/pebble.go
+++ b/storage/pebble.go
@@ -214,14 +214,6 @@ func (s *Pebble) loadTxIterator(
 ) (*pebble.Iterator, *pebble.Snapshot, error) {
 	fromKey := keyTx(fromBlockNum, fromTxIndex)
 
-	if toBlockNum == 0 {
-		toBlockNum = math.MaxInt64
-	}
-
-	if toTxIndex == 0 {
-		toTxIndex = math.MaxUint32
-	}
-
 	toKey := keyTx(toBlockNum, toTxIndex)
 
 	snap := s.db.NewSnapshot()
@@ -243,6 +235,14 @@ func (s *Pebble) TxIterator(
 	fromTxIndex,
 	toTxIndex uint32,
 ) (Iterator[*types.TxResult], error) {
+	if toBlockNum == 0 {
+		toBlockNum = math.MaxInt64
+	}
+
+	if toTxIndex == 0 {
+		toTxIndex = math.MaxUint32
+	}
+
 	it, snap, err := s.loadTxIterator(fromBlockNum, toBlockNum, fromTxIndex, toTxIndex)
 	if err != nil {
 		return nil, err
@@ -264,6 +264,14 @@ func (s *Pebble) TxReverseIterator(
 	fromTxIndex,
 	toTxIndex uint32,
 ) (Iterator[*types.TxResult], error) {
+	if toBlockNum == 0 {
+		toBlockNum = math.MaxInt64
+	}
+
+	if toTxIndex == 0 {
+		toTxIndex = math.MaxUint32
+	}
+
 	it, snap, err := s.loadTxIterator(fromBlockNum, toBlockNum, fromTxIndex, toTxIndex)
 	if err != nil {
 		return nil, err

--- a/storage/pebble_test.go
+++ b/storage/pebble_test.go
@@ -183,7 +183,7 @@ func TestStorageIters(t *testing.T) {
 			break
 		}
 
-		_, err := it.Value()
+		_, err = it.Value()
 		require.NoError(t, err)
 		require.NoError(t, it.Error())
 
@@ -191,6 +191,28 @@ func TestStorageIters(t *testing.T) {
 	}
 
 	require.Equal(t, 0, txCount)
+
+	// corner case: get all transactions from genesis
+	it, err = s.TxIterator(0, 0, 0, 0)
+	require.NoError(t, err)
+
+	txCount = 0
+
+	for {
+		if !it.Next() {
+			require.NoError(t, it.Error())
+
+			break
+		}
+
+		_, err := it.Value()
+		require.NoError(t, err)
+		require.NoError(t, it.Error())
+
+		txCount++
+	}
+
+	require.Equal(t, 100, txCount)
 }
 
 // generateRandomBlocks generates dummy blocks


### PR DESCRIPTION
When there are transactions on Genesis, and no filter is applied, we have to take into account the max toTxIndex range when filtering the out results.

This functionality can be deleted in the future when we delete deprecated graphql queries.