### PR TITLE
Fix an off-by-one on upper bounds when iterating data. 

### DIFF
--- a/storage/pebble.go
+++ b/storage/pebble.go
@@ -161,6 +161,8 @@ func (s *Pebble) loadBlockIterator(fromBlockNum, toBlockNum uint64) (*pebble.Ite
 
 	if toBlockNum == 0 {
 		toBlockNum = math.MaxInt64
+	} else {
+		toBlockNum++ // adding one to the range because the UpperBound is exclusive
 	}
 
 	toKey := keyBlock(toBlockNum)
@@ -192,6 +194,8 @@ func (s *Pebble) BlockReverseIterator(fromBlockNum, toBlockNum uint64) (Iterator
 
 	if toBlockNum == 0 {
 		toBlockNum = math.MaxInt64
+	} else {
+		toBlockNum++ // adding one to the range because the UpperBound is exclusive
 	}
 
 	toKey := keyBlock(toBlockNum)
@@ -240,10 +244,14 @@ func (s *Pebble) TxIterator(
 ) (Iterator[*types.TxResult], error) {
 	if toBlockNum == 0 {
 		toBlockNum = math.MaxInt64
+	} else {
+		toBlockNum++ // adding one to the range because the UpperBound is exclusive
 	}
 
 	if toTxIndex == 0 {
 		toTxIndex = math.MaxUint32
+	} else {
+		toTxIndex++ // adding one to the range because the UpperBound is exclusive
 	}
 
 	it, snap, err := s.loadTxIterator(fromBlockNum, toBlockNum, fromTxIndex, toTxIndex)
@@ -269,10 +277,14 @@ func (s *Pebble) TxReverseIterator(
 ) (Iterator[*types.TxResult], error) {
 	if toBlockNum == 0 {
 		toBlockNum = math.MaxInt64
+	} else {
+		toBlockNum++ // adding one to the range because the UpperBound is exclusive
 	}
 
 	if toTxIndex == 0 {
 		toTxIndex = math.MaxUint32
+	} else {
+		toTxIndex++ // adding one to the range because the UpperBound is exclusive
 	}
 
 	it, snap, err := s.loadTxIterator(fromBlockNum, toBlockNum, fromTxIndex, toTxIndex)

--- a/storage/pebble_test.go
+++ b/storage/pebble_test.go
@@ -145,7 +145,7 @@ func TestStorageIters(t *testing.T) {
 		txCount++
 	}
 
-	require.Equal(t, 3, txCount)
+	require.Equal(t, 4, txCount) // txs 0, 1, 2 AND 3
 
 	defer require.NoError(t, it.Close())
 
@@ -167,7 +167,7 @@ func TestStorageIters(t *testing.T) {
 		blockCount++
 	}
 
-	require.Equal(t, 2, blockCount)
+	require.Equal(t, 3, blockCount) // blocks 0, 1, AND 2
 
 	defer require.NoError(t, it2.Close())
 


### PR DESCRIPTION
Fix an off-by-one on upper bounds when iterating data.  Upper bound limit is exclusive in pebbleDB.

Fixes #175 