### PR TITLE
fix: update goreleaser config for cosign v2

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: tx-indexer
 
 before:
@@ -32,15 +34,14 @@ archives:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
+      - '--bundle=${artifact}.bundle'
       - '${artifact}'
-      - "--yes" # needed on cosign 2.0.0+
+      - "--yes"
     artifacts: checksum
     output: true
 
@@ -117,14 +118,13 @@ docker_manifests:
     
 docker_signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     artifacts: images
     output: true
     args:
       - 'sign'
+      - '--bundle=${artifact}.bundle'
       - '${artifact}'
-      - "--yes" # needed on cosign 2.0.0+
+      - "--yes"
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
## Summary
- Add `--bundle` flag to cosign `sign-blob` and `sign` commands — required by newer cosign versions
- Remove deprecated `COSIGN_EXPERIMENTAL=1` env var (keyless signing is default in cosign v2+)
- Upgrade goreleaser config to `version: 2`

Fixes the release CI failure: `must provide --bundle with --signing-config or --use-signing-config`