### PR TITLE
fix: remove --bundle from docker_signs

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -122,7 +122,6 @@ docker_signs:
     output: true
     args:
       - 'sign'
-      - '--bundle=${artifact}.bundle'
       - '${artifact}'
       - "--yes"
 


### PR DESCRIPTION
## Summary
- Remove `--bundle` flag from `docker_signs` cosign args — `--bundle` is only valid for `sign-blob`, not `sign`

Follow-up to #223. This fixes the docker image signing step that fails with `unknown flag: --bundle`.