### PR TITLE
fix: cosign v3 blob signing compatibility

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -39,7 +39,7 @@ signs:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
-      - '--bundle=${artifact}.bundle'
+      - '--use-signing-config=false'
       - '${artifact}'
       - "--yes"
     artifacts: checksum


### PR DESCRIPTION
## Summary
- Replace `--bundle` with `--use-signing-config=false` in goreleaser `signs` config
- Cosign v3 (installed by `cosign-installer@v4`) defaults `--use-signing-config=true`, which requires `--bundle` and only produces `.bundle` files
- goreleaser expects separate `.sig` and `.pem` files from `--output-signature`/`--output-certificate`
- Disabling signing config restores v2-compatible behavior, producing the separate files goreleaser needs