### PR TITLE
Add CORS support to the HTTP server

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -6,9 +6,11 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/cors"
 	"github.com/go-chi/httprate"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"go.uber.org/zap"
@@ -23,8 +25,9 @@ import (
 )
 
 const (
-	defaultRemote = "http://127.0.0.1:26657"
-	defaultDBPath = "indexer-db"
+	defaultRemote           = "http://127.0.0.1:26657"
+	defaultDBPath           = "indexer-db"
+	defaultCORSAllowOrigins = "*"
 )
 
 type startCfg struct {
@@ -39,6 +42,8 @@ type startCfg struct {
 	rateLimit int
 
 	disableIntrospection bool
+
+	corsAllowedOrigins string
 }
 
 // newStartCmd creates the indexer start command
@@ -117,6 +122,13 @@ func (c *startCfg) registerFlags(fs *flag.FlagSet) {
 		false,
 		"disable GraphQL introspection queries if needed. This will cause malfunctions when using the GraphQL playground",
 	)
+
+	fs.StringVar(
+		&c.corsAllowedOrigins,
+		"cors-allowed-origins",
+		defaultCORSAllowOrigins,
+		"a comma-separated list of origins allowed to make cross-origin requests to the GraphQL and JSON-RPC endpoints, or \"*\" to allow any origin. The indexer only serves public chain data, so the permissive default lets browser-based clients query it directly",
+	)
 }
 
 // exec executes the indexer start command
@@ -177,6 +189,13 @@ func (c *startCfg) exec(ctx context.Context) error {
 	)
 
 	mux := chi.NewMux()
+
+	mux.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   strings.Split(c.corsAllowedOrigins, ","),
+		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodOptions},
+		AllowedHeaders:   []string{"Content-Type"},
+		AllowCredentials: false,
+	}))
 
 	if c.rateLimit != 0 {
 		logger.Info("rate-limit set", zap.Int("rate-limit", c.rateLimit))

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -30,20 +30,21 @@ const (
 	defaultCORSAllowOrigins = "*"
 )
 
+// corsAllowedOriginsHelp is built up over multiple lines so each stays under
+// the linter's line-length limit.
+const corsAllowedOriginsHelp = "a comma-separated list of origins allowed to make cross-origin requests " +
+	"to the GraphQL and JSON-RPC endpoints, or \"*\" to allow any origin"
+
 type startCfg struct {
-	listenAddress string
-	remote        string
-	dbPath        string
-	logLevel      string
-
-	maxSlots     int
-	maxChunkSize int64
-
-	rateLimit int
-
+	listenAddress        string
+	remote               string
+	dbPath               string
+	logLevel             string
+	corsAllowedOrigins   string
+	maxSlots             int
+	maxChunkSize         int64
+	rateLimit            int
 	disableIntrospection bool
-
-	corsAllowedOrigins string
 }
 
 // newStartCmd creates the indexer start command
@@ -127,7 +128,7 @@ func (c *startCfg) registerFlags(fs *flag.FlagSet) {
 		&c.corsAllowedOrigins,
 		"cors-allowed-origins",
 		defaultCORSAllowOrigins,
-		"a comma-separated list of origins allowed to make cross-origin requests to the GraphQL and JSON-RPC endpoints, or \"*\" to allow any origin. The indexer only serves public chain data, so the permissive default lets browser-based clients query it directly",
+		corsAllowedOriginsHelp,
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/gnolang/gno v0.0.0-20260312093129-ef1836d36eb0
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/go-chi/cors v1.2.2
 	github.com/go-chi/httprate v0.15.0
 	github.com/google/uuid v1.6.0
 	github.com/madz-lab/insertion-queue v0.0.0-20230520191346-295d3348f63a

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/gnolang/gno v0.0.0-20260312093129-ef1836d36eb0 h1:6w2Zf+RSoSUbvlNn/Dt
 github.com/gnolang/gno v0.0.0-20260312093129-ef1836d36eb0/go.mod h1:990lKB5nQ8JHad9HZnGztOR5C0Q3KJQIsb9jB0pB6oE=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
+github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-chi/httprate v0.15.0 h1:j54xcWV9KGmPf/X4H32/aTH+wBlrvxL7P+SdnRqxh5g=
 github.com/go-chi/httprate v0.15.0/go.mod h1:rzGHhVrsBn3IMLYDOZQsSU4fJNWcjui4fWKJcCId1R4=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=


### PR DESCRIPTION
## Summary

The indexer only serves public, read-only chain data, but browser-based clients are currently blocked from querying it directly: `indexer.topaz.testnets.gno.land`'s GraphQL endpoint sends no `Access-Control-Allow-Origin` header at all, so any `fetch()` from a page on a different origin fails at the CORS preflight before the request ever reaches the server (confirmed live, not just in theory).

This adds `go-chi/cors` as middleware ahead of the existing rate limiter, plus a `--cors-allowed-origins` flag (comma-separated, default `"*"`) so operators who'd rather restrict it to specific origins can, without another code change.

## Test plan
- [x] `go build ./...` and `go vet ./cmd/...`
- [x] Ran the built binary locally and confirmed a real `OPTIONS` preflight against `/graphql/query` now returns `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: POST`, `Access-Control-Allow-Headers: Content-Type`
- [x] `--help` shows the new `-cors-allowed-origins` flag with its default