### PR TITLE
fix(fetch): refetch failed chunks instead of saving them incomplete

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -36,6 +36,11 @@ type Fetcher struct {
 	logger      *zap.Logger
 	chunkBuffer *slots
 
+	// retrying holds the chunk ranges whose fetch failed, mapped to whether
+	// the range is waiting to be respawned (true) or already back in flight
+	// (false). A range leaves the map only once it has been fetched in full
+	retrying map[chunkRange]bool
+
 	maxSlots        int
 	maxChunkSize    int64
 	latestChunkSize int
@@ -69,6 +74,8 @@ func New(
 		Queue:    make([]queue.Item, 0),
 		maxSlots: f.maxSlots,
 	}
+
+	f.retrying = make(map[chunkRange]bool)
 
 	return f
 }
@@ -194,6 +201,34 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 		return nil
 	}
 
+	// refetchFailedRanges respawns workers for the ranges whose previous fetch
+	// failed. Their slots stay reserved with a nil chunk, so the write loop
+	// cannot advance past them until a refetch succeeds
+	refetchFailedRanges := func() {
+		for gap, queued := range f.retrying {
+			if !queued {
+				// Already back in flight
+				continue
+			}
+
+			f.retrying[gap] = false
+
+			f.logger.Info(
+				"Refetching range",
+				zap.Uint64("from", gap.from),
+				zap.Uint64("to", gap.to),
+			)
+
+			// Spawn worker
+			info := &workerInfo{
+				chunkRange: gap,
+				resCh:      collectorCh,
+			}
+
+			go handleChunk(ctx, f.client, info)
+		}
+	}
+
 	// Start a listener for monitoring new blocks
 	ticker := time.NewTicker(f.queryInterval)
 	defer ticker.Stop()
@@ -211,10 +246,34 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 
 			return nil
 		case <-ticker.C:
+			refetchFailedRanges()
+
 			if err := attemptRangeFetch(); err != nil {
 				return err
 			}
 		case response := <-collectorCh:
+			if response.error != nil {
+				f.logger.Error(
+					"error encountered during chunk fetch, refetching range",
+					zap.Uint64("from", response.chunkRange.from),
+					zap.Uint64("to", response.chunkRange.to),
+					zap.String("error", response.error.Error()),
+				)
+
+				// The chunk is dropped rather than saved. A partially fetched
+				// chunk holds blocks whose transactions are missing, and
+				// committing it advances the saved height past them, so the
+				// fetcher would never revisit those blocks and the missing
+				// transactions would be lost for good. Leaving the slot
+				// reserved with a nil chunk blocks the write loop below until
+				// the refetch succeeds
+				f.retrying[response.chunkRange] = true
+
+				continue
+			}
+
+			delete(f.retrying, response.chunkRange)
+
 			// Find the slot index.
 			// The reason for this search, is because the underlying
 			// slots are shifted constantly to accommodate new ranges,
@@ -223,13 +282,6 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 			index := sort.Search(f.chunkBuffer.Len(), func(i int) bool {
 				return f.chunkBuffer.getSlot(i).chunkRange.from >= response.chunkRange.from
 			})
-
-			if response.error != nil {
-				f.logger.Error(
-					"error encountered during chunk fetch",
-					zap.String("error", response.error.Error()),
-				)
-			}
 
 			// Save the chunk
 			f.chunkBuffer.setChunk(index, response.chunk)

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -242,8 +242,9 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			f.logger.Info("Fetcher service shut down")
-			close(collectorCh)
 
+			// The channel is left open: workers still in flight deliver into
+			// its buffer (or bail out on the cancelled context) and exit
 			return nil
 		case <-ticker.C:
 			refetchFailedRanges()

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -917,6 +918,11 @@ func TestFetcher_FetchTransactions_Valid_EmptyBlocks(t *testing.T) {
 	})
 }
 
+// TestFetcher_InvalidBlocks covers blocks the storage layer refuses, which are
+// skipped so that a chain carrying data an older Amino cannot decode does not
+// stop the fetcher. The chunk itself is fetched cleanly here: a failed fetch is
+// refetched rather than saved, and is covered by
+// TestFetcher_ChunkFetchError_NoSilentGap
 func TestFetcher_InvalidBlocks(t *testing.T) {
 	t.Parallel()
 
@@ -992,18 +998,20 @@ func TestFetcher_InvalidBlocks(t *testing.T) {
 				}, nil
 			},
 			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
-				if num == 0 {
-					return &core_types.ResultBlockResults{
-						Height: int64(num),
-						Results: &state.ABCIResponses{
-							DeliverTxs: make([]abci.ResponseDeliverTx, 0),
-						},
-					}, nil
-				}
-
 				require.LessOrEqual(t, num, uint64(blockNum))
 
-				return nil, fmt.Errorf("unable to fetch result for block %d", num)
+				// The genesis block carries no transactions
+				deliverTxs := txCount
+				if num == 0 {
+					deliverTxs = 0
+				}
+
+				return &core_types.ResultBlockResults{
+					Height: int64(num),
+					Results: &state.ABCIResponses{
+						DeliverTxs: make([]abci.ResponseDeliverTx, deliverTxs),
+					},
+				}, nil
 			},
 			getGenesisFn: func() (*core_types.ResultGenesis, error) {
 				return &core_types.ResultGenesis{
@@ -1355,6 +1363,175 @@ func TestFetcher_GenesisNilResults(t *testing.T) {
 }
 
 // generateTransactions generates dummy transactions
+// TestFetcher_ChunkFetchError_NoSilentGap verifies that a chunk whose fetch
+// partially failed is refetched, instead of being committed incomplete.
+//
+// A node that has saved a block but has not finished executing it answers
+// block_results for that height with an error. The chunk then holds the block
+// with no transactions, and committing it advances the saved-height watermark
+// past a block that was never fully indexed, so the fetcher never revisits it
+// and the missing transactions are lost permanently.
+func TestFetcher_ChunkFetchError_NoSilentGap(t *testing.T) {
+	t.Parallel()
+
+	const (
+		blockNum = 10
+		txCount  = 2
+		badBlock = uint64(5)
+	)
+
+	var cancelFn context.CancelFunc
+
+	var (
+		txs    = generateTransactions(t, txCount)
+		blocks = generateBlocks(t, blockNum+1, txs)
+
+		mu            sync.Mutex
+		resultsFailed bool
+
+		txsByHeight         = make(map[int64]int)
+		watermarkViolations = make([]string, 0)
+		latestSaved         = uint64(0)
+
+		mockStorage = &mock.Storage{
+			GetLatestSavedHeightFn: func() (uint64, error) {
+				if latestSaved == 0 {
+					return 0, storageErrors.ErrNotFound
+				}
+
+				return latestSaved, nil
+			},
+			GetWriteBatchFn: func() storage.Batch {
+				return &mock.WriteBatch{
+					SetTxFn: func(result *types.TxResult) error {
+						txsByHeight[result.Height]++
+
+						return nil
+					},
+					SetLatestHeightFn: func(h uint64) error {
+						// Every block at or below the watermark must be fully indexed
+						for height := int64(1); height <= int64(h); height++ {
+							if txsByHeight[height] == txCount {
+								continue
+							}
+
+							watermarkViolations = append(
+								watermarkViolations,
+								fmt.Sprintf(
+									"watermark advanced to %d, but block %d holds %d/%d txs",
+									h,
+									height,
+									txsByHeight[height],
+									txCount,
+								),
+							)
+						}
+
+						latestSaved = h
+
+						if h >= blockNum {
+							cancelFn()
+						}
+
+						return nil
+					},
+				}
+			},
+		}
+
+		mockClient = &mockClient{
+			createBatchFn: func() clientTypes.Batch {
+				return &mockBatch{
+					executeFn: func(_ context.Context) ([]any, error) {
+						// Force the sequential fetch path
+						return nil, errors.New("batch unavailable")
+					},
+					countFn: func() int {
+						return 1 // to trigger execution
+					},
+				}
+			},
+			getLatestBlockNumberFn: func() (uint64, error) {
+				return uint64(blockNum), nil
+			},
+			getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+				return &core_types.ResultBlock{
+					Block: blocks[num],
+				}, nil
+			},
+			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				// The node holds the block, but has not finished applying it
+				if num == badBlock && !resultsFailed {
+					resultsFailed = true
+
+					return nil, errors.New("could not find results for height")
+				}
+
+				return &core_types.ResultBlockResults{
+					Height: int64(num),
+					Results: &state.ABCIResponses{
+						DeliverTxs: make([]abci.ResponseDeliverTx, txCount),
+					},
+				}, nil
+			},
+			getGenesisFn: func() (*core_types.ResultGenesis, error) {
+				return &core_types.ResultGenesis{
+					Genesis: &types.GenesisDoc{
+						AppState: gnoland.GnoGenesisState{
+							Balances: []gnoland.Balance{},
+							Txs:      []gnoland.TxWithMetadata{},
+						},
+					},
+				}, nil
+			},
+		}
+	)
+
+	// Create the fetcher
+	f := New(
+		mockStorage,
+		mockClient,
+		&mockEvents{},
+		WithLogger(zap.NewNop()),
+	)
+
+	// Short interval to force spawning
+	f.queryInterval = 100 * time.Millisecond
+
+	// The timeout is a backstop: the run ends when the watermark reaches the
+	// chain head, which only happens once the refetch succeeds
+	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFn()
+
+	// Run the fetch
+	require.NoError(t, f.FetchChainData(ctx))
+
+	mu.Lock()
+	exercised := resultsFailed
+	mu.Unlock()
+
+	require.True(t, exercised, "the block results failure path was never exercised")
+
+	// The watermark must never cover an incompletely indexed block
+	assert.Empty(t, watermarkViolations)
+
+	// Every block must end up with all of its transactions
+	for height := int64(1); height <= blockNum; height++ {
+		assert.Equalf(
+			t,
+			txCount,
+			txsByHeight[height],
+			"block %d indexed with %d/%d transactions",
+			height,
+			txsByHeight[height],
+			txCount,
+		)
+	}
+}
+
 func generateTransactions(t *testing.T, count int) []*std.Tx {
 	t.Helper()
 

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1712,6 +1712,119 @@ func TestFetcher_ChunkFetchError_NoSilentGap(t *testing.T) {
 	}
 }
 
+// TestFetcher_ShutdownWithInFlightWorkers verifies that shutting the fetcher
+// down while chunk workers are still in flight ends cleanly.
+//
+// Workers deliver their response over the collector channel whenever their
+// fetch completes, so a shutdown must leave the channel open for the late
+// deliveries to select against: closing it turns each one into a send on a
+// closed channel, which panics instead of shutting down.
+func TestFetcher_ShutdownWithInFlightWorkers(t *testing.T) {
+	t.Parallel()
+
+	const (
+		blockNum  = 20
+		chunkSize = 5
+		// Whether a late delivery trips on the shutdown is a coin flip per
+		// worker, so the scenario is repeated to make the outcome reliable
+		runs = 8
+	)
+
+	var (
+		txs    = generateTransactions(t, 1)
+		blocks = generateBlocks(t, blockNum+1, txs)
+	)
+
+	for run := 0; run < runs; run++ {
+		var (
+			cancelFn context.CancelFunc
+
+			// Released once FetchChainData has returned, so every gated
+			// worker delivers its response strictly after the shutdown
+			gate       = make(chan struct{})
+			cancelOnce sync.Once
+		)
+
+		mockStorage := &mock.Storage{
+			GetLatestSavedHeightFn: func() (uint64, error) {
+				return 0, storageErrors.ErrNotFound
+			},
+			GetWriteBatchFn: func() storage.Batch {
+				return &mock.WriteBatch{}
+			},
+		}
+
+		mockClient := &mockClient{
+			createBatchFn: func() clientTypes.Batch {
+				return &mockBatch{
+					executeFn: func(_ context.Context) ([]any, error) {
+						// Force the sequential fetch path
+						return nil, errors.New("batch unavailable")
+					},
+					countFn: func() int {
+						return 1 // to trigger execution
+					},
+				}
+			},
+			getLatestBlockNumberFn: func() (uint64, error) {
+				return uint64(blockNum), nil
+			},
+			getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+				return &core_types.ResultBlock{
+					Block: blocks[num],
+				}, nil
+			},
+			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+				// The genesis fetch runs before the worker loop starts
+				if num == 0 {
+					return &core_types.ResultBlockResults{
+						Height:  0,
+						Results: &state.ABCIResponses{},
+					}, nil
+				}
+
+				// The first worker to get here shuts the fetcher down; every
+				// worker then holds its response until the shutdown completes
+				cancelOnce.Do(cancelFn)
+				<-gate
+
+				return nil, errors.New("could not find results for height")
+			},
+			getGenesisFn: func() (*core_types.ResultGenesis, error) {
+				return &core_types.ResultGenesis{
+					Genesis: &types.GenesisDoc{
+						AppState: gnoland.GnoGenesisState{
+							Balances: []gnoland.Balance{},
+							Txs:      []gnoland.TxWithMetadata{},
+						},
+					},
+				}, nil
+			},
+		}
+
+		// Create the fetcher
+		f := New(
+			mockStorage,
+			mockClient,
+			&mockEvents{},
+			WithLogger(zap.NewNop()),
+		)
+
+		// Small chunks so the range fans out into several workers
+		f.maxChunkSize = chunkSize
+
+		// The timeout is a backstop: the first worker to fetch block results
+		// shuts the fetcher down
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cancelFn = cancel
+
+		require.NoError(t, f.FetchChainData(ctx))
+
+		close(gate)
+		cancel()
+	}
+}
+
 // generateTransactions generates dummy transactions
 func generateTransactions(t *testing.T, count int) []*std.Tx {
 	t.Helper()


### PR DESCRIPTION
## Summary

A chunk whose fetch partially fails is saved anyway, and the saved height advances past it — so the fetcher never returns to it and the transactions it missed are gone for good. The block is stored carrying its correct `NumTxs` but no transactions, which makes the loss invisible: `getBlocks` reports a count that `getTransactions` cannot produce.

Failed ranges are now refetched on the next tick instead of being committed partially. The slot stays reserved, so the saved height cannot move past a range that was not fetched in full.

## Why

On a gno.land testnet this had silently dropped **3,048 of 37,625 transactions (8.1%)**. Over a two-hour sample, the set of blocks missing their transactions matched the set of logged fetch errors exactly — 105 for 105.

Any transient RPC failure causes it. The common one is a `--remote` behind a load balancer: `/status` is answered by a node that has fully applied height H, while the follow-up `block_results` call lands on another node that has saved the block but not finished `ApplyBlock`, which answers `Could not find results for height #H` — or `height must be less than or equal to the current blockchain height` if it does not have the block yet. Both clear within a block.

## Behaviour change

A range that keeps failing now holds the fetcher back rather than being skipped. That is the intended trade: a stalled fetcher is visible from outside, since `/health` reports the saved height and it stops advancing, whereas a hole in the data is not, short of auditing the whole chain against the node.

`TestFetcher_InvalidBlocks` had `getBlockResultsFn` fail for every height, which is now refetched indefinitely. Its subject — blocks the storage layer refuses — is unchanged; only that mock now succeeds.

## Testing

`TestFetcher_ChunkFetchError_NoSilentGap` fails one block's results once, then asserts that every block ends up with all of its transactions and that the saved height never covers an incompletely indexed block. Against `main` it fails with `watermark advanced to 10, but block 5 holds 0/2 txs`.
