### PR TITLE
fix(fetch): pair batched block results with their block

### DIFF
--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1355,6 +1355,187 @@ func TestFetcher_GenesisNilResults(t *testing.T) {
 }
 
 // generateTransactions generates dummy transactions
+// TestFetcher_BatchResults_MatchTheirBlocks verifies that results fetched with
+// a batch request are paired with the block they belong to.
+//
+// Empty blocks are left out of the block results batch, so the response is
+// dense over the blocks that carry transactions while the chunk it fills is
+// indexed over every block in the range. Pairing the two by response position
+// attributes results to the wrong blocks as soon as a range mixes empty and
+// non-empty blocks.
+func TestFetcher_BatchResults_MatchTheirBlocks(t *testing.T) {
+	t.Parallel()
+
+	const (
+		blockNum = 6
+		txCount  = 2
+		// Blocks below this height are empty, the rest carry transactions
+		firstFullBlock = 4
+	)
+
+	var cancelFn context.CancelFunc
+
+	var (
+		txs    = generateTransactions(t, txCount)
+		blocks = make([]*types.Block, blockNum+1)
+
+		capturedEvents = make([]*indexerTypes.NewBlock, 0)
+	)
+
+	for height := 0; height <= blockNum; height++ {
+		blockTxs := types.Txs{}
+
+		if height >= firstFullBlock {
+			blockTxs = serializeTxs(t, txs)
+		}
+
+		blocks[height] = &types.Block{
+			Header: types.Header{
+				NumTxs: int64(len(blockTxs)),
+				Height: int64(height),
+			},
+			Data: types.Data{
+				Txs: blockTxs,
+			},
+		}
+	}
+
+	var (
+		mockEvents = &mockEvents{
+			signalEventFn: func(e events.Event) {
+				blockEvent, ok := e.(*indexerTypes.NewBlock)
+				require.True(t, ok)
+
+				capturedEvents = append(capturedEvents, blockEvent)
+			},
+		}
+
+		mockStorage = &mock.Storage{
+			GetLatestSavedHeightFn: func() (uint64, error) {
+				return 0, storageErrors.ErrNotFound
+			},
+			GetWriteBatchFn: func() storage.Batch {
+				return &mock.WriteBatch{
+					SetBlockFn: func(block *types.Block) error {
+						if block.Height == int64(blockNum) {
+							cancelFn()
+						}
+
+						return nil
+					},
+				}
+			},
+		}
+
+		// Serves batches the way a node does: one response per request,
+		// in request order, with the empty blocks left out of the results batch
+		mockClient = &mockClient{
+			createBatchFn: func() clientTypes.Batch {
+				var blockReqs, resultsReqs []uint64
+
+				return &mockBatch{
+					addBlockRequestFn: func(num uint64) error {
+						blockReqs = append(blockReqs, num)
+
+						return nil
+					},
+					addBlockResultsRequestFn: func(num uint64) error {
+						resultsReqs = append(resultsReqs, num)
+
+						return nil
+					},
+					countFn: func() int {
+						return len(blockReqs) + len(resultsReqs)
+					},
+					executeFn: func(_ context.Context) ([]any, error) {
+						responses := make([]any, 0, len(blockReqs)+len(resultsReqs))
+
+						for _, num := range blockReqs {
+							responses = append(responses, &core_types.ResultBlock{
+								Block: blocks[num],
+							})
+						}
+
+						for _, num := range resultsReqs {
+							responses = append(responses, &core_types.ResultBlockResults{
+								Height: int64(num),
+								Results: &state.ABCIResponses{
+									DeliverTxs: make([]abci.ResponseDeliverTx, blocks[num].NumTxs),
+								},
+							})
+						}
+
+						return responses, nil
+					},
+				}
+			},
+			getLatestBlockNumberFn: func() (uint64, error) {
+				return uint64(blockNum), nil
+			},
+			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+				return &core_types.ResultBlockResults{
+					Height: int64(num),
+					Results: &state.ABCIResponses{
+						DeliverTxs: make([]abci.ResponseDeliverTx, blocks[num].NumTxs),
+					},
+				}, nil
+			},
+			getGenesisFn: func() (*core_types.ResultGenesis, error) {
+				return &core_types.ResultGenesis{
+					Genesis: &types.GenesisDoc{
+						AppState: gnoland.GnoGenesisState{
+							Balances: []gnoland.Balance{},
+							Txs:      []gnoland.TxWithMetadata{},
+						},
+					},
+				}, nil
+			},
+		}
+	)
+
+	// Create the fetcher
+	f := New(
+		mockStorage,
+		mockClient,
+		mockEvents,
+		WithLogger(zap.NewNop()),
+	)
+
+	// Short interval to force spawning
+	f.queryInterval = 100 * time.Millisecond
+
+	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFn()
+
+	// Run the fetch
+	require.NoError(t, f.FetchChainData(ctx))
+
+	require.NotEmpty(t, capturedEvents)
+
+	for _, event := range capturedEvents {
+		assert.Lenf(
+			t,
+			event.Results,
+			int(event.Block.NumTxs),
+			"block %d announced with %d results for %d txs",
+			event.Block.Height,
+			len(event.Results),
+			event.Block.NumTxs,
+		)
+
+		for _, result := range event.Results {
+			assert.Equalf(
+				t,
+				event.Block.Height,
+				result.Height,
+				"block %d announced with a result from block %d",
+				event.Block.Height,
+				result.Height,
+			)
+		}
+	}
+}
+
 func generateTransactions(t *testing.T, count int) []*std.Tx {
 	t.Helper()
 

--- a/fetch/worker.go
+++ b/fetch/worker.go
@@ -168,7 +168,7 @@ func getTxResultFromBatch(ctx context.Context, blocks []*types.Block, client Cli
 	}
 
 	// Extract the results
-	for resultsIndex, resultsRaw := range blockResultsRaw {
+	for _, resultsRaw := range blockResultsRaw {
 		results, ok := resultsRaw.(*core_types.ResultBlockResults)
 		if !ok {
 			return nil, errors.New("unable to cast batch result into ResultBlockResults")
@@ -176,7 +176,14 @@ func getTxResultFromBatch(ctx context.Context, blocks []*types.Block, client Cli
 
 		height := results.Height
 		deliverTxs := results.Results.DeliverTxs
-		blockIndex := indexOfBlockHeight[height]
+
+		blockIndex, found := indexOfBlockHeight[height]
+		if !found {
+			return nil, fmt.Errorf(
+				"received block results for block %d, which is outside the fetched range",
+				height,
+			)
+		}
 
 		txResults := make([]*types.TxResult, blocks[blockIndex].NumTxs)
 
@@ -191,7 +198,11 @@ func getTxResultFromBatch(ctx context.Context, blocks []*types.Block, client Cli
 			txResults[txIndex] = result
 		}
 
-		fetchedResults[resultsIndex] = txResults
+		// Empty blocks are left out of the results batch, so its responses are
+		// dense over the blocks carrying transactions, while fetchedResults is
+		// indexed over every block in the range. Pairing the two by response
+		// position attributes results to the wrong blocks
+		fetchedResults[blockIndex] = txResults
 	}
 
 	return fetchedResults, nil


### PR DESCRIPTION
## Summary

Empty blocks are left out of the block results batch, so its response array is dense over the blocks that carry transactions, while the slice it fills is indexed over every block in the range. Pairing the two by response position hands each result set to the wrong block as soon as a range mixes empty and non-empty blocks.

For a chunk covering blocks 1 to 6 where only 4, 5 and 6 hold transactions, the three responses land on blocks 1, 2 and 3, and blocks 4, 5 and 6 get nothing. The `NewBlock` event pushed to websocket and filter subscribers then announces a block alongside another block's results, or with none at all.

Results are now written at the index of the block they belong to, which the loop already computes in order to build them. A lookup miss in `indexOfBlockHeight` also silently resolved to `0`, attributing results for an out-of-range height to the first block of the chunk; it now returns an error.

Stored data was never affected — each `TxResult` carries its own height and index, so `SetTx` keys it correctly wherever it sits in the chunk.

## Testing

`TestFetcher_BatchResults_MatchTheirBlocks` runs a range mixing empty and non-empty blocks through the batch path, asserting that every announced block carries exactly its own results.

That path had no coverage: every existing fetcher test makes `batch.Execute` fail, so only the sequential fallback was ever exercised.

---

Independent of #230, which fixes a separate fetcher bug found in the same investigation. Either can merge first.
