### PR TITLE
refactor(genesis): extract bootstrap, load genesis once per database

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - [Overview](#overview)
 - [Key Features](#key-features)
 - [Getting Started](#getting-started)
+  - [Genesis bootstrap](#genesis-bootstrap)
 - [GraphQL Endpoint](#graphql-endpoint)
   - [Hosted Example](#hosted-example)
   - [Examples](#examples)
@@ -96,6 +97,22 @@ FLAGS
   -remote http://127.0.0.1:26657  the JSON-RPC URL of the Gno chain
   -supply-denoms ugnot            comma-separated denominations whose supply (total/spendable/locked) is tracked and served by getSupply
 ```
+
+### Genesis bootstrap
+
+Before any service starts, the indexer loads the chain genesis into its database: the genesis block, so indexing can
+start from height 0, and the genesis balances, where the vesting schedules the supply endpoint needs live. This
+happens **once per database** — every later start reads what it needs from the DB and never fetches the genesis
+document again.
+
+Two consequences worth knowing when running it:
+
+- **The indexer will not start if it cannot bootstrap the genesis.** It retries while the node is unreachable, and
+  fails outright against a node that does not serve a readable gno genesis. Earlier versions logged the failure and
+  indexed anyway, at the cost of a missing block 0.
+- **A database is bound to its chain.** The chain ID is stored alongside the genesis and checked against the node on
+  every start, so pointing `--remote` at a different network while reusing `--db-path` refuses to start rather than
+  mixing two chains' data. Use a separate `--db-path` per chain.
 
 ## GraphQL Endpoint
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -16,7 +16,6 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"go.uber.org/zap"
 
-	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/gnolang/tx-indexer/client"
 	"github.com/gnolang/tx-indexer/events"
 	"github.com/gnolang/tx-indexer/fetch"
@@ -26,6 +25,8 @@ import (
 	"github.com/gnolang/tx-indexer/serve/handlers/supply"
 	"github.com/gnolang/tx-indexer/serve/health"
 	"github.com/gnolang/tx-indexer/storage"
+
+	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
 const (
@@ -198,21 +199,6 @@ func (c *startCfg) exec(ctx context.Context) error {
 		fetch.WithMaxChunkSize(c.maxChunkSize),
 	)
 
-	// Bootstrap the chain genesis into the storage before any service starts.
-	// Two of them read it from there afterwards: the fetcher indexes from
-	// height 0, and the supply handler folds the balances into vesting
-	// schedules. A no-op once the storage carries this chain's genesis.
-	if err := genesis.Bootstrap(
-		ctx,
-		db,
-		tm2Client,
-		genesis.WithLogger(
-			logger.Named("genesis"),
-		),
-	); err != nil {
-		return fmt.Errorf("unable to bootstrap genesis, %w", err)
-	}
-
 	// The supply handler serves both the JSON-RPC and GraphQL surfaces from
 	// one shared snapshot. It only ever queries the tracked denoms, on its
 	// own schedule, so request input never reaches the chain.
@@ -274,20 +260,68 @@ func (c *startCfg) exec(ctx context.Context) error {
 	// Create a new waiter
 	w := newWaiter(ctx)
 
-	// Add the fetcher service
-	w.add(f.FetchChainData)
+	// genesisReady is closed once the chain genesis is in the storage. Two
+	// services read it from there and so wait on it: the fetcher indexes from
+	// height 0, and the supply handler folds the genesis balances into vesting
+	// schedules.
+	genesisReady := make(chan struct{})
 
-	// Add the supply snapshot refresher
-	w.add(supplyHandler.Start)
+	// Add the genesis bootstrap. It runs beside the HTTP server rather than
+	// ahead of it, because it retries until the node answers: a restart during
+	// a node outage keeps serving what the storage already holds instead of
+	// leaving every port shut until the node is back. A no-op once the storage
+	// carries this chain's genesis.
+	w.add(func(ctx context.Context) error {
+		if err := genesis.Bootstrap(
+			ctx,
+			db,
+			tm2Client,
+			genesis.WithLogger(
+				logger.Named("genesis"),
+			),
+		); err != nil {
+			if errors.Is(err, context.Canceled) {
+				// Shut down while still retrying, like the other services
+				// returning on a cancelled context
+				return nil
+			}
+
+			return fmt.Errorf("unable to bootstrap genesis, %w", err)
+		}
+
+		close(genesisReady)
+
+		return nil
+	})
 
 	// Add the JSON-RPC service
 	w.add(hs.Serve)
+
+	// Add the fetcher service
+	w.add(afterGenesis(genesisReady, f.FetchChainData))
+
+	// Add the supply snapshot refresher
+	w.add(afterGenesis(genesisReady, supplyHandler.Start))
 
 	// Wait for the services to stop
 	return errors.Join(
 		w.wait(),
 		logger.Sync(),
 	)
+}
+
+// afterGenesis holds a service back until the genesis bootstrap has stored the
+// chain genesis, for the services that read it from the storage. A shutdown
+// before the bootstrap succeeds never starts the service at all.
+func afterGenesis(ready <-chan struct{}, fn waitFunc) waitFunc {
+	return func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ready:
+			return fn(ctx)
+		}
+	}
 }
 
 // parseSupplyDenoms splits the comma-separated flag value, validates each

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gnolang/tx-indexer/client"
 	"github.com/gnolang/tx-indexer/events"
 	"github.com/gnolang/tx-indexer/fetch"
+	"github.com/gnolang/tx-indexer/genesis"
 	"github.com/gnolang/tx-indexer/serve"
 	"github.com/gnolang/tx-indexer/serve/graph"
 	"github.com/gnolang/tx-indexer/serve/handlers/supply"
@@ -197,12 +198,18 @@ func (c *startCfg) exec(ctx context.Context) error {
 		fetch.WithMaxChunkSize(c.maxChunkSize),
 	)
 
-	// Bootstrap the chain genesis before any service starts. The fetcher
-	// needs the genesis block stored, and the supply handler needs the
-	// genesis balances, which is where the vesting schedules live. Doing
-	// it here means one fetch and one decode for both.
-	genesisBalances, err := f.BootstrapGenesis(ctx)
-	if err != nil {
+	// Bootstrap the chain genesis into the storage before any service starts.
+	// Two of them read it from there afterwards: the fetcher indexes from
+	// height 0, and the supply handler folds the balances into vesting
+	// schedules. A no-op once the storage carries this chain's genesis.
+	if err := genesis.Bootstrap(
+		ctx,
+		db,
+		tm2Client,
+		genesis.WithLogger(
+			logger.Named("genesis"),
+		),
+	); err != nil {
 		return fmt.Errorf("unable to bootstrap genesis, %w", err)
 	}
 
@@ -214,18 +221,13 @@ func (c *startCfg) exec(ctx context.Context) error {
 		return err
 	}
 
-	vestings, err := supply.NewVestings(genesisBalances)
-	if err != nil {
-		return fmt.Errorf("unable to parse genesis vesting schedules, %w", err)
-	}
-
 	supplyHandler := supply.NewHandler(
 		tm2Client,
+		db,
 		supply.WithLogger(
 			logger.Named("supply"),
 		),
 		supply.WithDenoms(denoms),
-		supply.WithVestings(vestings),
 	)
 
 	// Create the JSON-RPC service

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAfterGenesis_WaitsForBootstrap makes sure a service that reads the
+// genesis from the storage only starts once the bootstrap has put it there.
+func TestAfterGenesis_WaitsForBootstrap(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ready   = make(chan struct{})
+		started = make(chan struct{})
+	)
+
+	go func() {
+		require.NoError(t, afterGenesis(ready, func(context.Context) error {
+			close(started)
+
+			return nil
+		})(t.Context()))
+	}()
+
+	select {
+	case <-started:
+		require.FailNow(t, "the service started before the genesis was bootstrapped")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(ready)
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "the service never started")
+	}
+}
+
+// TestAfterGenesis_ShutdownBeforeBootstrap makes sure a shutdown while the
+// bootstrap is still retrying never starts the service, and stops cleanly.
+func TestAfterGenesis_ShutdownBeforeBootstrap(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.NoError(t, afterGenesis(make(chan struct{}), func(context.Context) error {
+		require.FailNow(t, "the service must not start")
+
+		return nil
+	})(ctx))
+}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -8,9 +8,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/gnolang/gno/gno.land/pkg/gnoland"
-	"github.com/gnolang/gno/tm2/pkg/amino"
-	bft_types "github.com/gnolang/gno/tm2/pkg/bft/types"
 	queue "github.com/madz-lab/insertion-queue"
 	"go.uber.org/zap"
 
@@ -23,8 +20,6 @@ const (
 	DefaultMaxSlots     = 100
 	DefaultMaxChunkSize = 100
 )
-
-var errInvalidGenesisState = errors.New("invalid genesis state")
 
 // Fetcher is an instance of the block indexer
 // fetcher
@@ -80,98 +75,9 @@ func New(
 	return f
 }
 
-// defaultGenesisBackoff is the pause between genesis bootstrap attempts.
-const defaultGenesisBackoff = 5 * time.Second
-
-// BootstrapGenesis loads the chain genesis, retrying until the node
-// answers or ctx is done. It runs before the other services because two
-// of them depend on it: the fetcher needs the genesis block stored to
-// index from height 0, and the supply handler needs the genesis balances
-// for the vesting schedules. The balances are returned as-is, duplicates
-// included.
-func (f *Fetcher) BootstrapGenesis(ctx context.Context) ([]gnoland.Balance, error) {
-	for {
-		balances, err := f.bootstrapGenesis(ctx)
-		if err == nil {
-			return balances, nil
-		}
-
-		f.logger.Warn("unable to bootstrap genesis, retrying", zap.Error(err))
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(defaultGenesisBackoff):
-		}
-	}
-}
-
-// bootstrapGenesis fetches the genesis document and, when the storage is
-// empty, writes the genesis block to it as a slot at height 0. The
-// document is fetched even when the storage is already populated: the
-// balances are not part of the stored block, so they can only come from
-// the document.
-func (f *Fetcher) bootstrapGenesis(ctx context.Context) ([]gnoland.Balance, error) {
-	f.logger.Info("Fetching genesis")
-
-	block, state, err := getGenesisBlock(ctx, f.client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch genesis block: %w", err)
-	}
-
-	_, err = f.storage.GetLatestHeight()
-	switch {
-	case err == nil:
-		// The storage already carries the chain. The genesis block is
-		// written, so only the balances are needed.
-		return state.Balances, nil
-	case !errors.Is(err, storageErrors.ErrNotFound):
-		// A storage error, not an empty storage.
-		return nil, err
-	}
-
-	results, err := f.client.GetBlockResults(ctx, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch genesis results: %w", err)
-	}
-
-	if results.Results == nil {
-		return nil, errors.New("nil results")
-	}
-
-	txResults := make([]*bft_types.TxResult, len(block.Txs))
-
-	for txIndex, tx := range block.Txs {
-		result := &bft_types.TxResult{
-			Height:   0,
-			Index:    uint32(txIndex),
-			Tx:       tx,
-			Response: results.Results.DeliverTxs[txIndex],
-		}
-
-		txResults[txIndex] = result
-	}
-
-	s := &slot{
-		chunk: &chunk{
-			blocks:  []*bft_types.Block{block},
-			results: [][]*bft_types.TxResult{txResults},
-		},
-		chunkRange: chunkRange{
-			from: 0,
-			to:   0,
-		},
-	}
-
-	if err := f.writeSlot(s); err != nil {
-		return nil, err
-	}
-
-	return state.Balances, nil
-}
-
-// FetchChainData starts the fetching process that indexes blockchain
-// data. The genesis block is loaded beforehand by BootstrapGenesis.
+// FetchChainData starts the fetching process that indexes
+// blockchain data. The genesis block is not handled here — the genesis
+// package bootstraps it into the storage before any service starts.
 func (f *Fetcher) FetchChainData(ctx context.Context) error {
 	collectorCh := make(chan *workerResponse, DefaultMaxSlots)
 
@@ -415,42 +321,4 @@ func (f *Fetcher) IsReady(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
-}
-
-func getGenesisBlock(ctx context.Context, client Client) (*bft_types.Block, gnoland.GnoGenesisState, error) {
-	gblock, err := client.GetGenesis(ctx)
-	if err != nil {
-		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to get genesis block: %w", err)
-	}
-
-	if gblock.Genesis == nil {
-		return nil, gnoland.GnoGenesisState{}, errInvalidGenesisState
-	}
-
-	genesisState, ok := gblock.Genesis.AppState.(gnoland.GnoGenesisState)
-	if !ok {
-		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unknown genesis state kind '%T'", gblock.Genesis.AppState)
-	}
-
-	txs := make([]bft_types.Tx, len(genesisState.Txs))
-	for i, tx := range genesisState.Txs {
-		txs[i], err = amino.Marshal(tx.Tx)
-		if err != nil {
-			return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to marshal genesis tx: %w", err)
-		}
-	}
-
-	block := &bft_types.Block{
-		Header: bft_types.Header{
-			NumTxs:   int64(len(txs)),
-			TotalTxs: int64(len(txs)),
-			Time:     gblock.Genesis.GenesisTime,
-			ChainID:  gblock.Genesis.ChainID,
-		},
-		Data: bft_types.Data{
-			Txs: txs,
-		},
-	}
-
-	return block, genesisState, nil
 }

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -21,11 +21,30 @@ import (
 
 	clientTypes "github.com/gnolang/tx-indexer/client/types"
 	"github.com/gnolang/tx-indexer/events"
+	"github.com/gnolang/tx-indexer/genesis"
 	"github.com/gnolang/tx-indexer/internal/mock"
 	"github.com/gnolang/tx-indexer/storage"
 	storageErrors "github.com/gnolang/tx-indexer/storage/errors"
 	indexerTypes "github.com/gnolang/tx-indexer/types"
 )
+
+// bootstrapGenesis runs the genesis bootstrap the way cmd/start.go does, so a
+// test's fetched blocks follow block 0 exactly as in production. Bounded on
+// purpose: the real bootstrap retries until it succeeds, which inside a test
+// would be a hang rather than a failure.
+func bootstrapGenesis(t *testing.T, store genesis.Storage, client genesis.Client) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, genesis.Bootstrap(
+		ctx,
+		store,
+		client,
+		genesis.WithBackoff(time.Millisecond),
+	))
+}
 
 func TestFetcher_FetchTransactions_Invalid(t *testing.T) {
 	t.Parallel()
@@ -192,9 +211,8 @@ func TestFetcher_FetchTransactions_Valid_FullBlocks(t *testing.T) {
 
 		// Run the fetch
 		// Bootstrap the genesis first, the way cmd/start.go does, so the
-		// genesis slot precedes the fetched blocks exactly as in production.
-		_, bootstrapErr := f.BootstrapGenesis(context.Background())
-		require.NoError(t, bootstrapErr)
+		// genesis block precedes the fetched blocks exactly as in production.
+		bootstrapGenesis(t, mockStorage, mockClient)
 
 		require.NoError(t, f.FetchChainData(ctx))
 
@@ -216,14 +234,14 @@ func TestFetcher_FetchTransactions_Valid_FullBlocks(t *testing.T) {
 			}
 		}
 
-		// Make sure proper events were emitted
-		require.Len(t, capturedEvents, len(blocks))
+		// Make sure proper events were emitted. One per fetched block: the
+		// genesis block is indexed by the genesis package, which signals
+		// nothing because no subscriber exists before the HTTP server starts.
+		require.Len(t, capturedEvents, blockNum)
 
 		for index, event := range capturedEvents {
-			if index == 0 {
-				// Dummy genesis block
-				continue
-			}
+			// capturedEvents[0] is block 1
+			blockIndex := index + 1
 
 			if event.GetType() != indexerTypes.NewBlockEvent {
 				continue
@@ -233,13 +251,13 @@ func TestFetcher_FetchTransactions_Valid_FullBlocks(t *testing.T) {
 			require.True(t, ok)
 
 			// Make sure the block is valid
-			assert.Equal(t, blocks[index], eventData.Block)
+			assert.Equal(t, blocks[blockIndex], eventData.Block)
 
 			// Make sure the transaction results are valid
 			require.Len(t, eventData.Results, txCount)
 
 			for txIndex, tx := range eventData.Results {
-				assert.EqualValues(t, blocks[index].Height, tx.Height)
+				assert.EqualValues(t, blocks[blockIndex].Height, tx.Height)
 				assert.EqualValues(t, txIndex, tx.Index)
 				assert.Equal(t, serializedTxs[txIndex], tx.Tx)
 			}
@@ -410,9 +428,8 @@ func TestFetcher_FetchTransactions_Valid_FullBlocks(t *testing.T) {
 
 		// Run the fetch
 		// Bootstrap the genesis first, the way cmd/start.go does, so the
-		// genesis slot precedes the fetched blocks exactly as in production.
-		_, bootstrapErr := f.BootstrapGenesis(context.Background())
-		require.NoError(t, bootstrapErr)
+		// genesis block precedes the fetched blocks exactly as in production.
+		bootstrapGenesis(t, mockStorage, mockClient)
 
 		require.NoError(t, f.FetchChainData(ctx))
 
@@ -434,24 +451,24 @@ func TestFetcher_FetchTransactions_Valid_FullBlocks(t *testing.T) {
 			}
 		}
 
-		// Make sure proper events were emitted
-		require.Len(t, capturedEvents, len(blocks))
+		// Make sure proper events were emitted. One per fetched block: the
+		// genesis block is indexed by the genesis package, which signals
+		// nothing because no subscriber exists before the HTTP server starts.
+		require.Len(t, capturedEvents, blockNum)
 
 		for index, event := range capturedEvents {
-			if index == 0 {
-				// Dummy genesis block
-				continue
-			}
+			// capturedEvents[0] is block 1
+			blockIndex := index + 1
 
 			// Make sure the block is valid
 			eventData := event.(*indexerTypes.NewBlock)
-			assert.Equal(t, blocks[index], eventData.Block)
+			assert.Equal(t, blocks[blockIndex], eventData.Block)
 
 			// Make sure the transaction results are valid
 			require.Len(t, eventData.Results, txCount)
 
 			for txIndex, tx := range eventData.Results {
-				assert.EqualValues(t, blocks[index].Height, tx.Height)
+				assert.EqualValues(t, blocks[blockIndex].Height, tx.Height)
 				assert.EqualValues(t, txIndex, tx.Index)
 				assert.Equal(t, serializedTxs[txIndex], tx.Tx)
 			}
@@ -596,9 +613,8 @@ func TestFetcher_FetchTransactions_Valid_FullTransactions(t *testing.T) {
 
 		// Run the fetch
 		// Bootstrap the genesis first, the way cmd/start.go does, so the
-		// genesis slot precedes the fetched blocks exactly as in production.
-		_, bootstrapErr := f.BootstrapGenesis(context.Background())
-		require.NoError(t, bootstrapErr)
+		// genesis block precedes the fetched blocks exactly as in production.
+		bootstrapGenesis(t, mockStorage, mockClient)
 
 		require.NoError(t, f.FetchChainData(ctx))
 
@@ -620,16 +636,15 @@ func TestFetcher_FetchTransactions_Valid_FullTransactions(t *testing.T) {
 			}
 		}
 
-		// Make sure proper events were emitted
+		// Make sure proper events were emitted. One per fetched block: the
+		// genesis block is indexed by the genesis package, which signals
+		// nothing because no subscriber exists before the HTTP server starts.
 		// Blocks each have as many transactions as txCount.
-		txEventCount := len(blocks)
-		require.Len(t, capturedEvents, txEventCount)
+		require.Len(t, capturedEvents, blockNum)
 
 		for index, event := range capturedEvents {
-			if index == 0 {
-				// Dummy genesis block
-				continue
-			}
+			// capturedEvents[0] is block 1
+			blockIndex := index + 1
 
 			if event.GetType() != indexerTypes.NewBlockEvent {
 				continue
@@ -639,13 +654,13 @@ func TestFetcher_FetchTransactions_Valid_FullTransactions(t *testing.T) {
 			require.True(t, ok)
 
 			// Make sure the block is valid
-			assert.Equal(t, blocks[index], eventData.Block)
+			assert.Equal(t, blocks[blockIndex], eventData.Block)
 
 			// Make sure the transaction results are valid
 			require.Len(t, eventData.Results, txCount)
 
 			for txIndex, tx := range eventData.Results {
-				assert.EqualValues(t, blocks[index].Height, tx.Height)
+				assert.EqualValues(t, blocks[blockIndex].Height, tx.Height)
 				assert.EqualValues(t, txIndex, tx.Index)
 				assert.Equal(t, serializedTxs[txIndex], tx.Tx)
 			}
@@ -764,9 +779,8 @@ func TestFetcher_FetchTransactions_Valid_EmptyBlocks(t *testing.T) {
 
 		// Run the fetch
 		// Bootstrap the genesis first, the way cmd/start.go does, so the
-		// genesis slot precedes the fetched blocks exactly as in production.
-		_, bootstrapErr := f.BootstrapGenesis(context.Background())
-		require.NoError(t, bootstrapErr)
+		// genesis block precedes the fetched blocks exactly as in production.
+		bootstrapGenesis(t, mockStorage, mockClient)
 
 		require.NoError(t, f.FetchChainData(ctx))
 
@@ -774,17 +788,15 @@ func TestFetcher_FetchTransactions_Valid_EmptyBlocks(t *testing.T) {
 			assert.Equal(t, blocks[blockIndex], savedBlocks[blockIndex])
 		}
 
-		// Make sure proper events were emitted
-		require.Len(t, capturedEvents, len(blocks))
+		// Make sure proper events were emitted. One per fetched block: the
+		// genesis block is indexed by the genesis package, which signals
+		// nothing because no subscriber exists before the HTTP server starts.
+		require.Len(t, capturedEvents, blockNum)
 
 		for index, event := range capturedEvents {
-			if index == 0 {
-				// Dummy genesis block
-				continue
-			}
-
+			// capturedEvents[0] is block 1
 			// Make sure the block is valid
-			assert.Equal(t, blocks[index], event.Block)
+			assert.Equal(t, blocks[index+1], event.Block)
 
 			// Make sure the transaction results are valid
 			require.Len(t, event.Results, 0)
@@ -915,9 +927,8 @@ func TestFetcher_FetchTransactions_Valid_EmptyBlocks(t *testing.T) {
 
 		// Run the fetch
 		// Bootstrap the genesis first, the way cmd/start.go does, so the
-		// genesis slot precedes the fetched blocks exactly as in production.
-		_, bootstrapErr := f.BootstrapGenesis(context.Background())
-		require.NoError(t, bootstrapErr)
+		// genesis block precedes the fetched blocks exactly as in production.
+		bootstrapGenesis(t, mockStorage, mockClient)
 
 		require.NoError(t, f.FetchChainData(ctx))
 
@@ -925,17 +936,15 @@ func TestFetcher_FetchTransactions_Valid_EmptyBlocks(t *testing.T) {
 			assert.Equal(t, blocks[blockIndex], savedBlocks[blockIndex])
 		}
 
-		// Make sure proper events were emitted
-		require.Len(t, capturedEvents, len(blocks))
+		// Make sure proper events were emitted. One per fetched block: the
+		// genesis block is indexed by the genesis package, which signals
+		// nothing because no subscriber exists before the HTTP server starts.
+		require.Len(t, capturedEvents, blockNum)
 
 		for index, event := range capturedEvents {
-			if index == 0 {
-				// Dummy genesis block
-				continue
-			}
-
+			// capturedEvents[0] is block 1
 			// Make sure the block is valid
-			assert.Equal(t, blocks[index], event.Block)
+			assert.Equal(t, blocks[index+1], event.Block)
 
 			// Make sure the transaction results are valid
 			require.Len(t, event.Results, 0)
@@ -1058,745 +1067,20 @@ func TestFetcher_InvalidBlocks(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
-	// Run the fetch
-	// Bootstrap the genesis first, the way cmd/start.go does, so the
-	// genesis slot precedes the fetched blocks exactly as in production.
-	_, bootstrapErr := f.BootstrapGenesis(context.Background())
-	require.NoError(t, bootstrapErr)
-
+	// Run the fetch. No genesis bootstrap here: this storage refuses every
+	// block, which the fetcher tolerates by design but the genesis bootstrap
+	// rightly does not — so the fetcher starts from height 1.
 	require.NoError(t, f.FetchChainData(ctx))
 
 	// Make sure correct blocks were attempted to be saved
 	for blockIndex := 1; blockIndex < blockNum; blockIndex++ {
-		assert.Equal(t, blocks[blockIndex], savedBlocks[blockIndex])
+		assert.Equal(t, blocks[blockIndex], savedBlocks[blockIndex-1])
 	}
 
 	// Make sure no events were emitted
 	assert.Len(t, capturedEvents, 0)
 }
 
-func TestFetcher_Genesis(t *testing.T) {
-	t.Parallel()
-
-	var (
-		txCount     = 21
-		txs         = generateGenesisTransactions(t, txCount)
-		savedBlocks = map[int64]*types.Block{}
-		savedTxs    = map[string]*types.TxResult{}
-
-		capturedEvents = make([]*indexerTypes.NewBlock, 0)
-
-		mockEvents = &mockEvents{
-			signalEventFn: func(e events.Event) {
-				blockEvent, ok := e.(*indexerTypes.NewBlock)
-				require.True(t, ok)
-
-				capturedEvents = append(capturedEvents, blockEvent)
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, storageErrors.ErrNotFound
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				return &mock.WriteBatch{
-					SetBlockFn: func(block *types.Block) error {
-						_, ok := savedBlocks[block.Height]
-						require.False(t, ok)
-
-						savedBlocks[block.Height] = block
-
-						return nil
-					},
-					SetTxFn: func(tx *types.TxResult) error {
-						savedTxs[fmt.Sprintf("%d-%d", tx.Height, tx.Index)] = tx
-
-						return nil
-					},
-				}
-			},
-		}
-
-		mockClient = &mockClient{
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return 0, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				localTxs := make([]gnoland.TxWithMetadata, len(txs))
-				for i, tx := range txs {
-					localTxs[i] = *tx
-				}
-
-				return &core_types.ResultGenesis{Genesis: &types.GenesisDoc{AppState: gnoland.GnoGenesisState{
-					Txs: localTxs,
-				}}}, nil
-			},
-			getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
-				return &core_types.ResultBlockResults{
-					Results: &state.ABCIResponses{
-						DeliverTxs: make([]abci.ResponseDeliverTx, len(txs)),
-					},
-				}, nil
-			},
-		}
-	)
-
-	f := New(mockStorage, mockClient, mockEvents)
-
-	balances, err := f.bootstrapGenesis(context.Background())
-	require.NoError(t, err)
-	// The genesis balances are what the supply handler folds into vesting
-	// schedules; they must travel out of the bootstrap.
-	require.Empty(t, balances)
-
-	require.Len(t, capturedEvents, 1)
-
-	_, ok := savedBlocks[0]
-	require.True(t, ok)
-
-	for i := uint32(0); i < uint32(len(txs)); i++ {
-		tx, ok := savedTxs[fmt.Sprintf("0-%d", i)]
-		require.True(t, ok)
-
-		expected := &types.TxResult{
-			Height:   0,
-			Index:    i,
-			Tx:       amino.MustMarshal(txs[i].Tx),
-			Response: abci.ResponseDeliverTx{},
-		}
-		require.Equal(t, expected, tx)
-	}
-}
-
-func TestFetcher_GenesisAlreadyFetched(t *testing.T) {
-	t.Parallel()
-
-	var (
-		mockEvents = &mockEvents{
-			signalEventFn: func(_ events.Event) {
-				require.Fail(t, "should not emit events")
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, nil
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				require.Fail(t, "should not attempt to write to storage")
-
-				return nil
-			},
-		}
-
-		mockClient = &mockClient{
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				// The genesis block is already stored, but the balances live
-				// only in the document, so it is still fetched.
-				return &core_types.ResultGenesis{Genesis: &types.GenesisDoc{
-					AppState: gnoland.GnoGenesisState{},
-				}}, nil
-			},
-			getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
-				require.Fail(t, "should not fetch block results for a stored genesis")
-
-				return nil, nil
-			},
-		}
-	)
-
-	f := New(mockStorage, mockClient, mockEvents)
-
-	balances, err := f.bootstrapGenesis(context.Background())
-	require.NoError(t, err)
-	require.Empty(t, balances)
-}
-
-func TestFetcher_GenesisFetchError(t *testing.T) {
-	t.Parallel()
-
-	var (
-		err       error
-		remoteErr = errors.New("remote error")
-
-		mockEvents = &mockEvents{
-			signalEventFn: func(_ events.Event) {
-				require.Fail(t, "should not emit events")
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, storageErrors.ErrNotFound
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				require.Fail(t, "should not attempt to write to storage")
-
-				return nil
-			},
-		}
-
-		mockClient = &mockClient{
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return 0, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				return nil, remoteErr
-			},
-			getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
-				require.Fail(t, "should not attempt to fetch block results")
-
-				return nil, nil
-			},
-		}
-	)
-
-	f := New(mockStorage, mockClient, mockEvents)
-
-	_, err = f.bootstrapGenesis(context.Background())
-	require.ErrorIs(t, err, remoteErr)
-}
-
-func TestFetcher_GenesisInvalidState(t *testing.T) {
-	t.Parallel()
-
-	var (
-		err        error
-		mockEvents = &mockEvents{
-			signalEventFn: func(_ events.Event) {
-				require.Fail(t, "should not emit events")
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, storageErrors.ErrNotFound
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				require.Fail(t, "should not attempt to write to storage")
-
-				return nil
-			},
-		}
-
-		mockClient = &mockClient{
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return 0, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				return &core_types.ResultGenesis{Genesis: &types.GenesisDoc{AppState: 0xdeadbeef}}, nil
-			},
-			getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
-				require.Fail(t, "should not attempt to fetch block results")
-
-				return nil, nil
-			},
-		}
-	)
-
-	f := New(mockStorage, mockClient, mockEvents)
-
-	_, err = f.bootstrapGenesis(context.Background())
-	require.ErrorContains(t, err, "unknown genesis state kind 'int'")
-}
-
-func TestFetcher_GenesisFetchResultsError(t *testing.T) {
-	t.Parallel()
-
-	var (
-		err       error
-		remoteErr = errors.New("remote error")
-
-		mockEvents = &mockEvents{
-			signalEventFn: func(_ events.Event) {
-				require.Fail(t, "should not emit events")
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, storageErrors.ErrNotFound
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				require.Fail(t, "should not attempt to write to storage")
-
-				return nil
-			},
-		}
-
-		mockClient = &mockClient{
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return 0, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				return &core_types.ResultGenesis{Genesis: &types.GenesisDoc{
-					AppState: gnoland.GnoGenesisState{Txs: []gnoland.TxWithMetadata{{}}},
-				}}, nil
-			},
-			getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
-				return nil, remoteErr
-			},
-		}
-	)
-
-	f := New(mockStorage, mockClient, mockEvents)
-
-	_, err = f.bootstrapGenesis(context.Background())
-	require.ErrorIs(t, err, remoteErr)
-}
-
-func TestFetcher_GenesisNilGenesisDoc(t *testing.T) {
-	t.Parallel()
-
-	var (
-		err        error
-		mockEvents = &mockEvents{
-			signalEventFn: func(_ events.Event) {
-				require.Fail(t, "should not emit events")
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, storageErrors.ErrNotFound
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				require.Fail(t, "should not attempt to write")
-
-				return nil
-			},
-		}
-
-		mockClient = &mockClient{
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return 0, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				return &core_types.ResultGenesis{Genesis: nil}, nil
-			},
-			getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
-				return &core_types.ResultBlockResults{Results: &state.ABCIResponses{}}, nil
-			},
-		}
-	)
-
-	f := New(mockStorage, mockClient, mockEvents)
-
-	_, err = f.bootstrapGenesis(context.Background())
-	require.Error(t, err)
-}
-
-func TestFetcher_GenesisNilResults(t *testing.T) {
-	t.Parallel()
-
-	var (
-		err        error
-		mockEvents = &mockEvents{
-			signalEventFn: func(_ events.Event) {
-				require.Fail(t, "should not emit events")
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, storageErrors.ErrNotFound
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				require.Fail(t, "should not attempt to write")
-
-				return nil
-			},
-		}
-
-		mockClient = &mockClient{
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return 0, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				return &core_types.ResultGenesis{Genesis: &types.GenesisDoc{
-					AppState: gnoland.GnoGenesisState{Txs: []gnoland.TxWithMetadata{{}}},
-				}}, nil
-			},
-			getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
-				return &core_types.ResultBlockResults{Results: nil}, nil
-			},
-		}
-	)
-
-	f := New(mockStorage, mockClient, mockEvents)
-
-	_, err = f.bootstrapGenesis(context.Background())
-	require.Error(t, err)
-}
-
-// TestFetcher_BatchResults_MatchTheirBlocks verifies that results fetched with
-// a batch request are paired with the block they belong to.
-//
-// Empty blocks are left out of the block results batch, so the response is
-// dense over the blocks that carry transactions while the chunk it fills is
-// indexed over every block in the range. Pairing the two by response position
-// attributes results to the wrong blocks as soon as a range mixes empty and
-// non-empty blocks.
-func TestFetcher_BatchResults_MatchTheirBlocks(t *testing.T) {
-	t.Parallel()
-
-	const (
-		blockNum = 6
-		txCount  = 2
-		// Blocks below this height are empty, the rest carry transactions
-		firstFullBlock = 4
-	)
-
-	var cancelFn context.CancelFunc
-
-	var (
-		txs    = generateTransactions(t, txCount)
-		blocks = make([]*types.Block, blockNum+1)
-
-		capturedEvents = make([]*indexerTypes.NewBlock, 0)
-	)
-
-	for height := 0; height <= blockNum; height++ {
-		blockTxs := types.Txs{}
-
-		if height >= firstFullBlock {
-			blockTxs = serializeTxs(t, txs)
-		}
-
-		blocks[height] = &types.Block{
-			Header: types.Header{
-				NumTxs: int64(len(blockTxs)),
-				Height: int64(height),
-			},
-			Data: types.Data{
-				Txs: blockTxs,
-			},
-		}
-	}
-
-	var (
-		mockEvents = &mockEvents{
-			signalEventFn: func(e events.Event) {
-				blockEvent, ok := e.(*indexerTypes.NewBlock)
-				require.True(t, ok)
-
-				capturedEvents = append(capturedEvents, blockEvent)
-			},
-		}
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				return 0, storageErrors.ErrNotFound
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				return &mock.WriteBatch{
-					SetBlockFn: func(block *types.Block) error {
-						if block.Height == int64(blockNum) {
-							cancelFn()
-						}
-
-						return nil
-					},
-				}
-			},
-		}
-
-		// Serves batches the way a node does: one response per request,
-		// in request order, with the empty blocks left out of the results batch
-		mockClient = &mockClient{
-			createBatchFn: func() clientTypes.Batch {
-				var blockReqs, resultsReqs []uint64
-
-				return &mockBatch{
-					addBlockRequestFn: func(num uint64) error {
-						blockReqs = append(blockReqs, num)
-
-						return nil
-					},
-					addBlockResultsRequestFn: func(num uint64) error {
-						resultsReqs = append(resultsReqs, num)
-
-						return nil
-					},
-					countFn: func() int {
-						return len(blockReqs) + len(resultsReqs)
-					},
-					executeFn: func(_ context.Context) ([]any, error) {
-						responses := make([]any, 0, len(blockReqs)+len(resultsReqs))
-
-						for _, num := range blockReqs {
-							responses = append(responses, &core_types.ResultBlock{
-								Block: blocks[num],
-							})
-						}
-
-						for _, num := range resultsReqs {
-							responses = append(responses, &core_types.ResultBlockResults{
-								Height: int64(num),
-								Results: &state.ABCIResponses{
-									DeliverTxs: make([]abci.ResponseDeliverTx, blocks[num].NumTxs),
-								},
-							})
-						}
-
-						return responses, nil
-					},
-				}
-			},
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return uint64(blockNum), nil
-			},
-			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
-				return &core_types.ResultBlockResults{
-					Height: int64(num),
-					Results: &state.ABCIResponses{
-						DeliverTxs: make([]abci.ResponseDeliverTx, blocks[num].NumTxs),
-					},
-				}, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				return &core_types.ResultGenesis{
-					Genesis: &types.GenesisDoc{
-						AppState: gnoland.GnoGenesisState{
-							Balances: []gnoland.Balance{},
-							Txs:      []gnoland.TxWithMetadata{},
-						},
-					},
-				}, nil
-			},
-		}
-	)
-
-	// Create the fetcher
-	f := New(
-		mockStorage,
-		mockClient,
-		mockEvents,
-		WithLogger(zap.NewNop()),
-	)
-
-	// Short interval to force spawning
-	f.queryInterval = 100 * time.Millisecond
-
-	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancelFn()
-
-	// Run the fetch
-	// Bootstrap the genesis first, the way cmd/start.go does, so the
-	// genesis slot precedes the fetched blocks exactly as in production.
-	_, bootstrapErr := f.BootstrapGenesis(context.Background())
-	require.NoError(t, bootstrapErr)
-
-	require.NoError(t, f.FetchChainData(ctx))
-
-	require.NotEmpty(t, capturedEvents)
-
-	for _, event := range capturedEvents {
-		assert.Lenf(
-			t,
-			event.Results,
-			int(event.Block.NumTxs),
-			"block %d announced with %d results for %d txs",
-			event.Block.Height,
-			len(event.Results),
-			event.Block.NumTxs,
-		)
-
-		for _, result := range event.Results {
-			assert.Equalf(
-				t,
-				event.Block.Height,
-				result.Height,
-				"block %d announced with a result from block %d",
-				event.Block.Height,
-				result.Height,
-			)
-		}
-	}
-}
-
-// TestFetcher_ChunkFetchError_NoSilentGap verifies that a chunk whose fetch
-// partially failed is refetched, instead of being committed incomplete.
-//
-// A node that has saved a block but has not finished executing it answers
-// block_results for that height with an error. The chunk then holds the block
-// with no transactions, and committing it advances the saved-height watermark
-// past a block that was never fully indexed, so the fetcher never revisits it
-// and the missing transactions are lost permanently.
-func TestFetcher_ChunkFetchError_NoSilentGap(t *testing.T) {
-	t.Parallel()
-
-	const (
-		blockNum = 10
-		txCount  = 2
-		badBlock = uint64(5)
-	)
-
-	var cancelFn context.CancelFunc
-
-	var (
-		txs    = generateTransactions(t, txCount)
-		blocks = generateBlocks(t, blockNum+1, txs)
-
-		mu            sync.Mutex
-		resultsFailed bool
-
-		txsByHeight         = make(map[int64]int)
-		watermarkViolations = make([]string, 0)
-		latestSaved         = uint64(0)
-
-		mockStorage = &mock.Storage{
-			GetLatestSavedHeightFn: func() (uint64, error) {
-				if latestSaved == 0 {
-					return 0, storageErrors.ErrNotFound
-				}
-
-				return latestSaved, nil
-			},
-			GetWriteBatchFn: func() storage.Batch {
-				return &mock.WriteBatch{
-					SetTxFn: func(result *types.TxResult) error {
-						txsByHeight[result.Height]++
-
-						return nil
-					},
-					SetLatestHeightFn: func(h uint64) error {
-						// Every block at or below the watermark must be fully indexed
-						for height := int64(1); height <= int64(h); height++ {
-							if txsByHeight[height] == txCount {
-								continue
-							}
-
-							watermarkViolations = append(
-								watermarkViolations,
-								fmt.Sprintf(
-									"watermark advanced to %d, but block %d holds %d/%d txs",
-									h,
-									height,
-									txsByHeight[height],
-									txCount,
-								),
-							)
-						}
-
-						latestSaved = h
-
-						if h >= blockNum {
-							cancelFn()
-						}
-
-						return nil
-					},
-				}
-			},
-		}
-
-		mockClient = &mockClient{
-			createBatchFn: func() clientTypes.Batch {
-				return &mockBatch{
-					executeFn: func(_ context.Context) ([]any, error) {
-						// Force the sequential fetch path
-						return nil, errors.New("batch unavailable")
-					},
-					countFn: func() int {
-						return 1 // to trigger execution
-					},
-				}
-			},
-			getLatestBlockNumberFn: func() (uint64, error) {
-				return uint64(blockNum), nil
-			},
-			getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
-				return &core_types.ResultBlock{
-					Block: blocks[num],
-				}, nil
-			},
-			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
-				mu.Lock()
-				defer mu.Unlock()
-
-				// The node holds the block, but has not finished applying it
-				if num == badBlock && !resultsFailed {
-					resultsFailed = true
-
-					return nil, errors.New("could not find results for height")
-				}
-
-				return &core_types.ResultBlockResults{
-					Height: int64(num),
-					Results: &state.ABCIResponses{
-						DeliverTxs: make([]abci.ResponseDeliverTx, txCount),
-					},
-				}, nil
-			},
-			getGenesisFn: func() (*core_types.ResultGenesis, error) {
-				return &core_types.ResultGenesis{
-					Genesis: &types.GenesisDoc{
-						AppState: gnoland.GnoGenesisState{
-							Balances: []gnoland.Balance{},
-							Txs:      []gnoland.TxWithMetadata{},
-						},
-					},
-				}, nil
-			},
-		}
-	)
-
-	// Create the fetcher
-	f := New(
-		mockStorage,
-		mockClient,
-		&mockEvents{},
-		WithLogger(zap.NewNop()),
-	)
-
-	// Short interval to force spawning
-	f.queryInterval = 100 * time.Millisecond
-
-	// The timeout is a backstop: the run ends when the watermark reaches the
-	// chain head, which only happens once the refetch succeeds
-	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancelFn()
-
-	// Run the fetch
-	// Bootstrap the genesis first, the way cmd/start.go does, so the
-	// genesis slot precedes the fetched blocks exactly as in production.
-	_, bootstrapErr := f.BootstrapGenesis(context.Background())
-	require.NoError(t, bootstrapErr)
-
-	require.NoError(t, f.FetchChainData(ctx))
-
-	mu.Lock()
-	exercised := resultsFailed
-	mu.Unlock()
-
-	require.True(t, exercised, "the block results failure path was never exercised")
-
-	// The watermark must never cover an incompletely indexed block
-	assert.Empty(t, watermarkViolations)
-
-	// Every block must end up with all of its transactions
-	for height := int64(1); height <= blockNum; height++ {
-		assert.Equalf(
-			t,
-			txCount,
-			txsByHeight[height],
-			"block %d indexed with %d/%d transactions",
-			height,
-			txsByHeight[height],
-			txCount,
-		)
-	}
-}
-
-// TestFetcher_ShutdownWithInFlightWorkers verifies that shutting the fetcher
-// down while chunk workers are still in flight ends cleanly.
-//
-// Workers deliver their response over the collector channel whenever their
-// fetch completes, so a shutdown must leave the channel open for the late
-// deliveries to select against: closing it turns each one into a send on a
-// closed channel, which panics instead of shutting down.
 func TestFetcher_ShutdownWithInFlightWorkers(t *testing.T) {
 	t.Parallel()
 
@@ -1897,9 +1181,8 @@ func TestFetcher_ShutdownWithInFlightWorkers(t *testing.T) {
 		cancelFn = cancel
 
 		// Bootstrap the genesis first, the way cmd/start.go does, so the
-		// genesis slot precedes the fetched blocks exactly as in production.
-		_, bootstrapErr := f.BootstrapGenesis(context.Background())
-		require.NoError(t, bootstrapErr)
+		// genesis block precedes the fetched blocks exactly as in production.
+		bootstrapGenesis(t, mockStorage, mockClient)
 
 		require.NoError(t, f.FetchChainData(ctx))
 

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -1206,23 +1206,6 @@ func generateTransactions(t *testing.T, count int) []*std.Tx {
 	return txs
 }
 
-// generateGenesisTransactions generates dummy genesis transactions
-func generateGenesisTransactions(t *testing.T, count int) []*gnoland.TxWithMetadata {
-	t.Helper()
-
-	txs := make([]*gnoland.TxWithMetadata, count)
-
-	for i := 0; i < count; i++ {
-		txs[i] = &gnoland.TxWithMetadata{
-			Tx: std.Tx{
-				Memo: fmt.Sprintf("memo %d", i),
-			},
-		}
-	}
-
-	return txs
-}
-
 // generateBlocks generates dummy blocks
 func generateBlocks(
 	t *testing.T,

--- a/fetch/mocks_test.go
+++ b/fetch/mocks_test.go
@@ -14,6 +14,7 @@ type (
 	getBlockDelegate             func(uint64) (*core_types.ResultBlock, error)
 	getBlockResultsDelegate      func(uint64) (*core_types.ResultBlockResults, error)
 	getGenesisDelegate           func() (*core_types.ResultGenesis, error)
+	getStatusDelegate            func() (*core_types.ResultStatus, error)
 
 	createBatchDelegate func() clientTypes.Batch
 )
@@ -23,6 +24,7 @@ type mockClient struct {
 	getBlockFn             getBlockDelegate
 	getBlockResultsFn      getBlockResultsDelegate
 	getGenesisFn           getGenesisDelegate
+	getStatusFn            getStatusDelegate
 
 	createBatchFn createBatchDelegate
 }
@@ -49,6 +51,18 @@ func (m *mockClient) GetGenesis(ctx context.Context) (*core_types.ResultGenesis,
 	}
 
 	return nil, nil
+}
+
+// GetStatus reports the empty chain ID by default, matching the empty ChainID
+// the genesis fixtures carry, so the bootstrap's chain check passes for tests
+// that are not about it. Non-nil on purpose: the bootstrap reads NodeInfo off
+// the result.
+func (m *mockClient) GetStatus(ctx context.Context) (*core_types.ResultStatus, error) {
+	if m.getStatusFn != nil {
+		return m.getStatusFn()
+	}
+
+	return &core_types.ResultStatus{}, nil
 }
 
 func (m *mockClient) GetBlockResults(ctx context.Context, blockNum uint64) (*core_types.ResultBlockResults, error) {

--- a/fetch/types.go
+++ b/fetch/types.go
@@ -17,9 +17,6 @@ type Client interface {
 	// GetBlock returns specified block
 	GetBlock(context.Context, uint64) (*core_types.ResultBlock, error)
 
-	// GetGenesis returns the genesis block
-	GetGenesis(context.Context) (*core_types.ResultGenesis, error)
-
 	// GetBlockResults returns the results of executing the transactions
 	// for the specified block
 	GetBlockResults(context.Context, uint64) (*core_types.ResultBlockResults, error)

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -1,0 +1,283 @@
+// Package genesis bootstraps the chain genesis into the storage, once per
+// database, before any service starts. Two consumers depend on it and neither
+// owns it: the fetcher needs the genesis block stored to index from height 0,
+// and the supply handler needs the genesis balances, where the vesting
+// schedules live.
+package genesis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	bft_types "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"go.uber.org/zap"
+
+	"github.com/gnolang/tx-indexer/storage"
+	storageErrors "github.com/gnolang/tx-indexer/storage/errors"
+)
+
+// defaultBackoff is the pause between bootstrap attempts
+const defaultBackoff = 5 * time.Second
+
+var (
+	// ErrInvalidState means the node served something that is not a gno genesis
+	ErrInvalidState = errors.New("invalid genesis state")
+
+	// ErrChainIDMismatch means the storage and the node disagree about which
+	// chain this is. Every stored block is suspect, not just the genesis data,
+	// so it is never retried — it needs an operator, not another attempt
+	ErrChainIDMismatch = errors.New("chain ID mismatch")
+)
+
+// Bootstrap loads the chain genesis into the storage, retrying until the node
+// answers or ctx is done. It is a no-op once the storage carries a genesis for
+// the same chain, so the genesis document is fetched exactly once per database
+// and a restart costs nothing.
+func Bootstrap(ctx context.Context, store Storage, client Client, opts ...Option) error {
+	cfg := &config{
+		logger:  zap.NewNop(),
+		backoff: defaultBackoff,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	for {
+		err := bootstrap(ctx, store, client, cfg)
+		if err == nil {
+			return nil
+		}
+
+		// Only transient failures are worth another attempt. A mismatch or a
+		// genesis the indexer cannot read are facts about the deployment: the
+		// answer will not change, and retrying would spin forever while
+		// logging a warning every backoff.
+		if errors.Is(err, ErrChainIDMismatch) || errors.Is(err, ErrInvalidState) {
+			return err
+		}
+
+		cfg.logger.Warn("unable to bootstrap genesis, retrying", zap.Error(err))
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(cfg.backoff):
+		}
+	}
+}
+
+func bootstrap(ctx context.Context, store Storage, client Client, cfg *config) error {
+	// The chain ID is written last, so its presence means the whole genesis
+	// landed. Checking it costs one small read — the balances stay untouched.
+	storedChainID, storedErr := store.GetGenesisChainID()
+	if storedErr != nil && !errors.Is(storedErr, storageErrors.ErrNotFound) {
+		return storedErr
+	}
+
+	status, err := client.GetStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to fetch the chain status: %w", err)
+	}
+
+	chainID := status.NodeInfo.Network
+
+	if storedErr == nil {
+		if storedChainID != chainID {
+			return fmt.Errorf(
+				"%w: storage holds genesis for chain %q, node reports %q",
+				ErrChainIDMismatch, storedChainID, chainID,
+			)
+		}
+
+		return nil
+	}
+
+	cfg.logger.Info("Fetching genesis")
+
+	doc, state, err := fetchState(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	if doc.ChainID != chainID {
+		return fmt.Errorf(
+			"%w: genesis declares chain %q, node reports %q",
+			ErrChainIDMismatch, doc.ChainID, chainID,
+		)
+	}
+
+	// Only index the genesis block into an empty storage. Writing it into a
+	// populated one would reset the latest height and force a full re-index.
+	indexBlock, err := storageEmpty(store)
+	if err != nil {
+		return err
+	}
+
+	// One batch for everything: either the whole genesis is in the storage or
+	// none of it is, so there is no half-bootstrapped state to reason about.
+	wb := store.WriteBatch()
+
+	if indexBlock {
+		if err := indexGenesisBlock(ctx, client, wb, doc, state); err != nil {
+			return rollback(wb, err)
+		}
+	}
+
+	if err := wb.SetGenesisBalances(state.Balances); err != nil {
+		return rollback(wb, fmt.Errorf("unable to save the genesis balances: %w", err))
+	}
+
+	if err := wb.SetGenesisChainID(chainID); err != nil {
+		return rollback(wb, fmt.Errorf("unable to save the genesis chain ID: %w", err))
+	}
+
+	if err := wb.Commit(); err != nil {
+		return fmt.Errorf("unable to persist the genesis into the storage: %w", err)
+	}
+
+	cfg.logger.Info(
+		"Genesis bootstrapped",
+		zap.String("chain-id", chainID),
+		zap.Int("balances", len(state.Balances)),
+		zap.Bool("block-indexed", indexBlock),
+	)
+
+	return nil
+}
+
+// storageEmpty reports whether the storage carries no chain data yet.
+func storageEmpty(store Storage) (bool, error) {
+	_, err := store.GetLatestHeight()
+
+	switch {
+	case err == nil:
+		return false, nil
+	case errors.Is(err, storageErrors.ErrNotFound):
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
+// indexGenesisBlock adds the genesis block and its transactions to the batch.
+//
+// Unlike the fetcher's writeSlot, a block that cannot be stored fails the whole
+// bootstrap rather than being logged and skipped. That tolerance exists so one
+// unencodable legacy block cannot stop the fetcher; here it would leave block 0
+// permanently missing, since a completed bootstrap is never retried.
+func indexGenesisBlock(
+	ctx context.Context,
+	client Client,
+	wb storage.Batch,
+	doc *bft_types.GenesisDoc,
+	state gnoland.GnoGenesisState,
+) error {
+	block, err := blockFrom(doc, state)
+	if err != nil {
+		return err
+	}
+
+	results, err := client.GetBlockResults(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("unable to fetch the genesis results: %w", err)
+	}
+
+	if results.Results == nil {
+		return errors.New("nil genesis results")
+	}
+
+	deliverTxs := results.Results.DeliverTxs
+	if len(deliverTxs) < len(block.Txs) {
+		// Only the first len(block.Txs) results are consumed, so a longer set
+		// is harmless — a shorter one would read past the end of the slice.
+		return fmt.Errorf(
+			"%w: genesis results are short of the genesis block: %d txs, %d results",
+			ErrInvalidState, len(block.Txs), len(deliverTxs),
+		)
+	}
+
+	if err := wb.SetBlock(block); err != nil {
+		return fmt.Errorf("unable to save the genesis block: %w", err)
+	}
+
+	for txIndex, tx := range block.Txs {
+		if err := wb.SetTx(&bft_types.TxResult{
+			Height:   0,
+			Index:    uint32(txIndex),
+			Tx:       tx,
+			Response: deliverTxs[txIndex],
+		}); err != nil {
+			return fmt.Errorf("unable to save the genesis tx %d: %w", txIndex, err)
+		}
+	}
+
+	return wb.SetLatestHeight(0)
+}
+
+// fetchState fetches the genesis document and decodes its gno app state. Cheap
+// relative to blockFrom, which is why the two are separate.
+func fetchState(
+	ctx context.Context,
+	client Client,
+) (*bft_types.GenesisDoc, gnoland.GnoGenesisState, error) {
+	gblock, err := client.GetGenesis(ctx)
+	if err != nil {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to get the genesis: %w", err)
+	}
+
+	if gblock.Genesis == nil {
+		return nil, gnoland.GnoGenesisState{}, ErrInvalidState
+	}
+
+	state, ok := gblock.Genesis.AppState.(gnoland.GnoGenesisState)
+	if !ok {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf(
+			"%w: unknown genesis state kind '%T'", ErrInvalidState, gblock.Genesis.AppState,
+		)
+	}
+
+	return gblock.Genesis, state, nil
+}
+
+// blockFrom builds the genesis block from the decoded state. It marshals every
+// genesis tx — the whole of a chain's initial packages — so it is only reached
+// when the block is actually going to be indexed.
+func blockFrom(
+	doc *bft_types.GenesisDoc,
+	state gnoland.GnoGenesisState,
+) (*bft_types.Block, error) {
+	var err error
+
+	txs := make([]bft_types.Tx, len(state.Txs))
+	for i, tx := range state.Txs {
+		txs[i], err = amino.Marshal(tx.Tx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal the genesis tx %d: %w", i, err)
+		}
+	}
+
+	return &bft_types.Block{
+		Header: bft_types.Header{
+			NumTxs:   int64(len(txs)),
+			TotalTxs: int64(len(txs)),
+			Time:     doc.GenesisTime,
+			ChainID:  doc.ChainID,
+		},
+		Data: bft_types.Data{
+			Txs: txs,
+		},
+	}, nil
+}
+
+func rollback(wb storage.Batch, cause error) error {
+	if err := wb.Rollback(); err != nil {
+		return fmt.Errorf("%w, and the rollback failed: %w", cause, err)
+	}
+
+	return cause
+}

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -56,12 +56,12 @@ func testBalance(t *testing.T) gnoland.Balance {
 // recorder captures what a bootstrap wrote, in order.
 type recorder struct {
 	batch        *mock.WriteBatch
+	latestHeight *uint64
+	chainID      string
 	writes       []string
 	blocks       []*bft_types.Block
 	txs          []*bft_types.TxResult
 	balances     []gnoland.Balance
-	chainID      string
-	latestHeight *uint64
 }
 
 func newRecorder() *recorder {
@@ -237,12 +237,6 @@ func TestBootstrap_BlockIndexedChainIDMissing(t *testing.T) {
 func TestBootstrap_ChainIDMismatch(t *testing.T) {
 	t.Parallel()
 
-	noWrites := func() storage.Batch {
-		require.Fail(t, "should not write anything")
-
-		return nil
-	}
-
 	t.Run("stored chain ID disagrees with the node", func(t *testing.T) {
 		t.Parallel()
 
@@ -250,7 +244,11 @@ func TestBootstrap_ChainIDMismatch(t *testing.T) {
 			GetGenesisChainIDFn: func() (string, error) {
 				return "test3", nil
 			},
-			GetWriteBatchFn: noWrites,
+			GetWriteBatchFn: func() storage.Batch {
+				require.Fail(t, "should not write anything")
+
+				return nil
+			},
 		}
 
 		client := &mockClient{
@@ -271,7 +269,11 @@ func TestBootstrap_ChainIDMismatch(t *testing.T) {
 			GetLatestSavedHeightFn: func() (uint64, error) {
 				return 0, storageErrors.ErrNotFound
 			},
-			GetWriteBatchFn: noWrites,
+			GetWriteBatchFn: func() storage.Batch {
+				require.Fail(t, "should not write anything")
+
+				return nil
+			},
 		}
 
 		client := &mockClient{

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -1,0 +1,475 @@
+package genesis
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	"github.com/gnolang/gno/tm2/pkg/bft/state"
+	bft_types "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	p2pTypes "github.com/gnolang/gno/tm2/pkg/p2p/types"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gnolang/tx-indexer/internal/mock"
+	"github.com/gnolang/tx-indexer/storage"
+	storageErrors "github.com/gnolang/tx-indexer/storage/errors"
+)
+
+const testChainID = "test-chain"
+
+// statusFor builds the minimal chain status the bootstrap reads.
+func statusFor(chainID string) *core_types.ResultStatus {
+	return &core_types.ResultStatus{
+		NodeInfo: p2pTypes.NodeInfo{
+			Network: chainID,
+		},
+	}
+}
+
+func genesisFor(chainID string, balances []gnoland.Balance, txs []gnoland.TxWithMetadata) *core_types.ResultGenesis {
+	return &core_types.ResultGenesis{
+		Genesis: &bft_types.GenesisDoc{
+			ChainID: chainID,
+			AppState: gnoland.GnoGenesisState{
+				Balances: balances,
+				Txs:      txs,
+			},
+		},
+	}
+}
+
+func testBalance(t *testing.T) gnoland.Balance {
+	t.Helper()
+
+	return gnoland.Balance{
+		Address: crypto.MustAddressFromString("g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq"),
+		Amount:  std.MustParseCoins("1000ugnot"),
+	}
+}
+
+// recorder captures what a bootstrap wrote, in order.
+type recorder struct {
+	batch        *mock.WriteBatch
+	writes       []string
+	blocks       []*bft_types.Block
+	txs          []*bft_types.TxResult
+	balances     []gnoland.Balance
+	chainID      string
+	latestHeight *uint64
+}
+
+func newRecorder() *recorder {
+	r := &recorder{}
+
+	r.batch = &mock.WriteBatch{
+		SetBlockFn: func(block *bft_types.Block) error {
+			r.blocks = append(r.blocks, block)
+			r.writes = append(r.writes, "block")
+
+			return nil
+		},
+		SetTxFn: func(tx *bft_types.TxResult) error {
+			r.txs = append(r.txs, tx)
+
+			return nil
+		},
+		SetLatestHeightFn: func(h uint64) error {
+			r.latestHeight = &h
+
+			return nil
+		},
+		SetGenesisBalancesFn: func(balances []gnoland.Balance) error {
+			r.balances = balances
+			r.writes = append(r.writes, "balances")
+
+			return nil
+		},
+		SetGenesisChainIDFn: func(chainID string) error {
+			r.chainID = chainID
+			r.writes = append(r.writes, "chainid")
+
+			return nil
+		},
+	}
+
+	return r
+}
+
+func (r *recorder) storage() *mock.Storage {
+	return &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			return 0, storageErrors.ErrNotFound
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			return r.batch
+		},
+	}
+}
+
+// bootstrapOnce runs one attempt, so a failing case reports an error instead of
+// retrying until the test times out.
+func bootstrapOnce(t *testing.T, store Storage, client Client) error {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	return Bootstrap(ctx, store, client, WithBackoff(time.Millisecond))
+}
+
+// A cold start indexes the genesis block and stores the balances, with the
+// chain ID written last so its presence means the whole genesis landed.
+func TestBootstrap_ColdStart(t *testing.T) {
+	t.Parallel()
+
+	balance := testBalance(t)
+	rec := newRecorder()
+
+	client := &mockClient{
+		getStatusFn: func() (*core_types.ResultStatus, error) {
+			return statusFor(testChainID), nil
+		},
+		getGenesisFn: func() (*core_types.ResultGenesis, error) {
+			return genesisFor(testChainID, []gnoland.Balance{balance}, nil), nil
+		},
+		getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
+			return &core_types.ResultBlockResults{Results: &state.ABCIResponses{}}, nil
+		},
+	}
+
+	require.NoError(t, bootstrapOnce(t, rec.storage(), client))
+
+	require.Equal(t, []string{"block", "balances", "chainid"}, rec.writes)
+	require.Equal(t, testChainID, rec.chainID)
+	require.Equal(t, []gnoland.Balance{balance}, rec.balances)
+	require.Len(t, rec.blocks, 1)
+	require.EqualValues(t, 0, rec.blocks[0].Height)
+	require.NotNil(t, rec.latestHeight)
+	require.EqualValues(t, 0, *rec.latestHeight)
+}
+
+// The whole point of persisting: once the chain ID is there, the genesis
+// document is never fetched again, and the balances are not even read.
+func TestBootstrap_AlreadyDone(t *testing.T) {
+	t.Parallel()
+
+	var genesisCalls int
+
+	store := &mock.Storage{
+		GetGenesisChainIDFn: func() (string, error) {
+			return testChainID, nil
+		},
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			require.Fail(t, "a completed genesis needs no height probe")
+
+			return 0, nil
+		},
+		GetGenesisBalancesFn: func() ([]gnoland.Balance, error) {
+			require.Fail(t, "the completion check must not decode the balances")
+
+			return nil, nil
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			require.Fail(t, "should not write anything")
+
+			return nil
+		},
+	}
+
+	client := &mockClient{
+		getStatusFn: func() (*core_types.ResultStatus, error) {
+			return statusFor(testChainID), nil
+		},
+		getGenesisFn: func() (*core_types.ResultGenesis, error) {
+			genesisCalls++
+
+			return nil, nil
+		},
+	}
+
+	require.NoError(t, bootstrapOnce(t, store, client))
+	require.Zero(t, genesisCalls, "the genesis document must not be fetched again")
+}
+
+// A storage populated before the genesis record existed has block 0 but no
+// chain ID: the balances are fetched and stored, the block is not re-indexed —
+// re-indexing it would reset the latest height and force a full re-sync.
+func TestBootstrap_BlockIndexedChainIDMissing(t *testing.T) {
+	t.Parallel()
+
+	balance := testBalance(t)
+	rec := newRecorder()
+
+	store := rec.storage()
+	store.GetLatestSavedHeightFn = func() (uint64, error) {
+		return 5_000_000, nil
+	}
+
+	client := &mockClient{
+		getStatusFn: func() (*core_types.ResultStatus, error) {
+			return statusFor(testChainID), nil
+		},
+		getGenesisFn: func() (*core_types.ResultGenesis, error) {
+			return genesisFor(testChainID, []gnoland.Balance{balance}, nil), nil
+		},
+		getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
+			require.Fail(t, "should not fetch results for an already indexed genesis")
+
+			return nil, nil
+		},
+	}
+
+	require.NoError(t, bootstrapOnce(t, store, client))
+
+	require.Equal(t, []string{"balances", "chainid"}, rec.writes)
+	require.Nil(t, rec.latestHeight, "the latest height must be left alone")
+	require.Empty(t, rec.blocks)
+}
+
+// A storage holding one chain's genesis must not be served by a node running
+// another, and the mismatch must not be retried.
+func TestBootstrap_ChainIDMismatch(t *testing.T) {
+	t.Parallel()
+
+	noWrites := func() storage.Batch {
+		require.Fail(t, "should not write anything")
+
+		return nil
+	}
+
+	t.Run("stored chain ID disagrees with the node", func(t *testing.T) {
+		t.Parallel()
+
+		store := &mock.Storage{
+			GetGenesisChainIDFn: func() (string, error) {
+				return "test3", nil
+			},
+			GetWriteBatchFn: noWrites,
+		}
+
+		client := &mockClient{
+			getStatusFn: func() (*core_types.ResultStatus, error) {
+				return statusFor("test7"), nil
+			},
+		}
+
+		err := bootstrapOnce(t, store, client)
+		require.ErrorIs(t, err, ErrChainIDMismatch)
+		require.NotErrorIs(t, err, context.DeadlineExceeded, "a mismatch must not be retried")
+	})
+
+	t.Run("fetched genesis disagrees with the node", func(t *testing.T) {
+		t.Parallel()
+
+		store := &mock.Storage{
+			GetLatestSavedHeightFn: func() (uint64, error) {
+				return 0, storageErrors.ErrNotFound
+			},
+			GetWriteBatchFn: noWrites,
+		}
+
+		client := &mockClient{
+			getStatusFn: func() (*core_types.ResultStatus, error) {
+				return statusFor("test7"), nil
+			},
+			getGenesisFn: func() (*core_types.ResultGenesis, error) {
+				return genesisFor("test3", nil, nil), nil
+			},
+		}
+
+		err := bootstrapOnce(t, store, client)
+		require.ErrorIs(t, err, ErrChainIDMismatch)
+		require.NotErrorIs(t, err, context.DeadlineExceeded)
+	})
+}
+
+// A failed fetch must leave nothing behind, so the next attempt starts over
+// rather than treating a half-finished bootstrap as done.
+func TestBootstrap_RetriedUntilSuccess(t *testing.T) {
+	t.Parallel()
+
+	var genesisCalls int
+
+	rec := newRecorder()
+
+	client := &mockClient{
+		getStatusFn: func() (*core_types.ResultStatus, error) {
+			return statusFor(testChainID), nil
+		},
+		getGenesisFn: func() (*core_types.ResultGenesis, error) {
+			genesisCalls++
+
+			// Fail twice, then answer.
+			if genesisCalls < 3 {
+				return nil, errors.New("node unreachable")
+			}
+
+			return genesisFor(testChainID, nil, nil), nil
+		},
+		getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
+			return &core_types.ResultBlockResults{Results: &state.ABCIResponses{}}, nil
+		},
+	}
+
+	require.NoError(t, bootstrapOnce(t, rec.storage(), client))
+
+	require.Equal(t, 3, genesisCalls, "a failed fetch must be retried, not recorded as done")
+	require.Equal(t, []string{"block", "balances", "chainid"}, rec.writes)
+}
+
+// Unlike the fetcher's writeSlot, a genesis block that cannot be stored fails
+// the bootstrap rather than being logged and skipped: recording the genesis as
+// done without block 0 would leave the gap permanently. A storage failure may
+// clear, so it stays retryable — it just never completes.
+func TestBootstrap_BlockWriteFailurePreventsCompletion(t *testing.T) {
+	t.Parallel()
+
+	store := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			return 0, storageErrors.ErrNotFound
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			return &mock.WriteBatch{
+				SetBlockFn: func(*bft_types.Block) error {
+					return errors.New("unencodable block")
+				},
+				SetGenesisChainIDFn: func(string) error {
+					require.Fail(t, "the genesis must not be recorded without block 0")
+
+					return nil
+				},
+			}
+		},
+	}
+
+	client := &mockClient{
+		getStatusFn: func() (*core_types.ResultStatus, error) {
+			return statusFor(testChainID), nil
+		},
+		getGenesisFn: func() (*core_types.ResultGenesis, error) {
+			return genesisFor(testChainID, nil, nil), nil
+		},
+		getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
+			return &core_types.ResultBlockResults{Results: &state.ABCIResponses{}}, nil
+		},
+	}
+
+	// Retried, so the deadline is what surfaces; the guard above is what proves
+	// the genesis was never recorded as done.
+	require.Error(t, bootstrapOnce(t, store, client))
+}
+
+// The node answering with fewer results than the genesis has transactions would
+// read past the end of the slice.
+func TestBootstrap_ShortResults(t *testing.T) {
+	t.Parallel()
+
+	txs := []gnoland.TxWithMetadata{
+		{Tx: std.Tx{Memo: "genesis tx 0"}},
+		{Tx: std.Tx{Memo: "genesis tx 1"}},
+	}
+
+	rec := newRecorder()
+
+	client := &mockClient{
+		getStatusFn: func() (*core_types.ResultStatus, error) {
+			return statusFor(testChainID), nil
+		},
+		getGenesisFn: func() (*core_types.ResultGenesis, error) {
+			return genesisFor(testChainID, nil, txs), nil
+		},
+		getBlockResultsFn: func(uint64) (*core_types.ResultBlockResults, error) {
+			return &core_types.ResultBlockResults{
+				Results: &state.ABCIResponses{
+					DeliverTxs: make([]abci.ResponseDeliverTx, 1),
+				},
+			}, nil
+		},
+	}
+
+	err := bootstrapOnce(t, rec.storage(), client)
+	require.ErrorContains(t, err, "short of the genesis block")
+	require.NotContains(t, rec.writes, "chainid")
+}
+
+func TestBootstrap_InvalidState(t *testing.T) {
+	t.Parallel()
+
+	store := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			return 0, storageErrors.ErrNotFound
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			require.Fail(t, "should not write anything")
+
+			return nil
+		},
+	}
+
+	t.Run("nil genesis doc", func(t *testing.T) {
+		t.Parallel()
+
+		client := &mockClient{
+			getStatusFn: func() (*core_types.ResultStatus, error) {
+				return statusFor(testChainID), nil
+			},
+			getGenesisFn: func() (*core_types.ResultGenesis, error) {
+				return &core_types.ResultGenesis{}, nil
+			},
+		}
+
+		require.ErrorIs(t, bootstrapOnce(t, store, client), ErrInvalidState)
+	})
+
+	t.Run("not a gno genesis", func(t *testing.T) {
+		t.Parallel()
+
+		client := &mockClient{
+			getStatusFn: func() (*core_types.ResultStatus, error) {
+				return statusFor(testChainID), nil
+			},
+			getGenesisFn: func() (*core_types.ResultGenesis, error) {
+				return &core_types.ResultGenesis{
+					Genesis: &bft_types.GenesisDoc{
+						ChainID:  testChainID,
+						AppState: 0xdeadbeef,
+					},
+				}, nil
+			},
+		}
+
+		require.ErrorIs(t, bootstrapOnce(t, store, client), ErrInvalidState)
+	})
+}
+
+// Cancellation is the only way out of a persistent chain problem.
+func TestBootstrap_CancelledWhileRetrying(t *testing.T) {
+	t.Parallel()
+
+	store := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) {
+			return 0, storageErrors.ErrNotFound
+		},
+	}
+
+	client := &mockClient{
+		getStatusFn: func() (*core_types.ResultStatus, error) {
+			return nil, errors.New("node unreachable")
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	require.ErrorIs(
+		t,
+		Bootstrap(ctx, store, client, WithBackoff(time.Millisecond)),
+		context.DeadlineExceeded,
+	)
+}

--- a/genesis/mocks_test.go
+++ b/genesis/mocks_test.go
@@ -1,0 +1,37 @@
+package genesis
+
+import (
+	"context"
+
+	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+)
+
+type mockClient struct {
+	getGenesisFn      func() (*core_types.ResultGenesis, error)
+	getStatusFn       func() (*core_types.ResultStatus, error)
+	getBlockResultsFn func(uint64) (*core_types.ResultBlockResults, error)
+}
+
+func (m *mockClient) GetGenesis(_ context.Context) (*core_types.ResultGenesis, error) {
+	if m.getGenesisFn != nil {
+		return m.getGenesisFn()
+	}
+
+	return nil, nil
+}
+
+func (m *mockClient) GetStatus(_ context.Context) (*core_types.ResultStatus, error) {
+	if m.getStatusFn != nil {
+		return m.getStatusFn()
+	}
+
+	return &core_types.ResultStatus{}, nil
+}
+
+func (m *mockClient) GetBlockResults(_ context.Context, blockNum uint64) (*core_types.ResultBlockResults, error) {
+	if m.getBlockResultsFn != nil {
+		return m.getBlockResultsFn(blockNum)
+	}
+
+	return nil, nil
+}

--- a/genesis/options.go
+++ b/genesis/options.go
@@ -1,0 +1,28 @@
+package genesis
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type Option func(c *config)
+
+type config struct {
+	logger  *zap.Logger
+	backoff time.Duration
+}
+
+// WithLogger sets the logger to be used with the bootstrap
+func WithLogger(logger *zap.Logger) Option {
+	return func(c *config) {
+		c.logger = logger
+	}
+}
+
+// WithBackoff sets the pause between bootstrap attempts
+func WithBackoff(backoff time.Duration) Option {
+	return func(c *config) {
+		c.backoff = backoff
+	}
+}

--- a/genesis/types.go
+++ b/genesis/types.go
@@ -1,0 +1,38 @@
+package genesis
+
+import (
+	"context"
+
+	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+
+	"github.com/gnolang/tx-indexer/storage"
+)
+
+// Client is the chain access the bootstrap needs
+type Client interface {
+	// GetGenesis returns the chain genesis document
+	GetGenesis(context.Context) (*core_types.ResultGenesis, error)
+
+	// GetStatus returns the chain status, for the chain ID the stored genesis
+	// is validated against
+	GetStatus(context.Context) (*core_types.ResultStatus, error)
+
+	// GetBlockResults returns the results of executing the transactions
+	// for the specified block
+	GetBlockResults(context.Context, uint64) (*core_types.ResultBlockResults, error)
+}
+
+// Storage is the storage access the bootstrap needs. Narrow on purpose: the
+// chain ID says whether there is any work to do, and the latest height says
+// whether the genesis block is already indexed
+type Storage interface {
+	// GetLatestHeight returns the latest block height from the storage
+	GetLatestHeight() (uint64, error)
+
+	// GetGenesisChainID returns the chain ID of the bootstrapped genesis
+	GetGenesisChainID() (string, error)
+
+	// WriteBatch provides a batch intended to do a write action that
+	// can be cancelled or committed all at the same time
+	WriteBatch() storage.Batch
+}

--- a/internal/mock/storage.go
+++ b/internal/mock/storage.go
@@ -1,15 +1,19 @@
 package mock
 
 import (
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 
 	"github.com/gnolang/tx-indexer/storage"
+	storageErrors "github.com/gnolang/tx-indexer/storage/errors"
 )
 
 var _ storage.Storage = &Storage{}
 
 type Storage struct {
 	GetLatestSavedHeightFn func() (uint64, error)
+	GetGenesisChainIDFn    func() (string, error)
+	GetGenesisBalancesFn   func() ([]gnoland.Balance, error)
 	GetWriteBatchFn        func() storage.Batch
 	GetBlockFn             func(uint64) (*types.Block, error)
 	GetTxFn                func(uint64, uint32) (*types.TxResult, error)
@@ -22,6 +26,26 @@ func (m *Storage) GetLatestHeight() (uint64, error) {
 	}
 
 	return 0, nil
+}
+
+// GetGenesisChainID fetches the bootstrapped chain ID. It defaults to
+// ErrNotFound — "the genesis has not been bootstrapped yet" — so a test that
+// does not care exercises the fetch-and-store path rather than skipping it.
+func (m *Storage) GetGenesisChainID() (string, error) {
+	if m.GetGenesisChainIDFn != nil {
+		return m.GetGenesisChainIDFn()
+	}
+
+	return "", storageErrors.ErrNotFound
+}
+
+// GetGenesisBalances fetches the stored genesis balance rows
+func (m *Storage) GetGenesisBalances() ([]gnoland.Balance, error) {
+	if m.GetGenesisBalancesFn != nil {
+		return m.GetGenesisBalancesFn()
+	}
+
+	return nil, storageErrors.ErrNotFound
 }
 
 // GetBlock fetches the block by its number
@@ -94,15 +118,35 @@ func (m *Storage) Close() error {
 }
 
 type WriteBatch struct {
-	SetLatestHeightFn func(uint64) error
-	SetBlockFn        func(*types.Block) error
-	SetTxFn           func(*types.TxResult) error
+	SetLatestHeightFn    func(uint64) error
+	SetGenesisBalancesFn func([]gnoland.Balance) error
+	SetGenesisChainIDFn  func(string) error
+	SetBlockFn           func(*types.Block) error
+	SetTxFn              func(*types.TxResult) error
 }
 
 // SetLatestHeight saves the latest block height to the storage
 func (mb *WriteBatch) SetLatestHeight(h uint64) error {
 	if mb.SetLatestHeightFn != nil {
 		return mb.SetLatestHeightFn(h)
+	}
+
+	return nil
+}
+
+// SetGenesisBalances saves the genesis balance rows to the permanent storage
+func (mb *WriteBatch) SetGenesisBalances(balances []gnoland.Balance) error {
+	if mb.SetGenesisBalancesFn != nil {
+		return mb.SetGenesisBalancesFn(balances)
+	}
+
+	return nil
+}
+
+// SetGenesisChainID saves the genesis chain ID to the permanent storage
+func (mb *WriteBatch) SetGenesisChainID(chainID string) error {
+	if mb.SetGenesisChainIDFn != nil {
+		return mb.SetGenesisChainIDFn(chainID)
 	}
 
 	return nil

--- a/serve/handlers/supply/supply.go
+++ b/serve/handlers/supply/supply.go
@@ -7,14 +7,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
+	"github.com/gnolang/gno/tm2/pkg/amino"
 	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/overflow"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"go.uber.org/zap"
-
-	"github.com/gnolang/gno/gno.land/pkg/gnoland"
-	"github.com/gnolang/gno/tm2/pkg/amino"
 
 	"github.com/gnolang/tx-indexer/serve/metadata"
 	"github.com/gnolang/tx-indexer/serve/methods"
@@ -48,6 +47,14 @@ type Client interface {
 	ABCIQueryBatchAtHeight(ctx context.Context, height int64, paths []string) ([]*core_types.ResultABCIQuery, error)
 }
 
+// Storage is the storage access the supply handler needs. The genesis balance
+// rows are put there by the startup bootstrap, so the handler reads its own
+// input instead of having it threaded down from main.
+type Storage interface {
+	// GetGenesisBalances returns the stored genesis balance rows, unfolded
+	GetGenesisBalances() ([]gnoland.Balance, error)
+}
+
 // Vesting is one genesis vesting account, with the schedule pre-built
 // into an account so the locked math is the chain's own.
 type Vesting struct {
@@ -61,9 +68,9 @@ type Vesting struct {
 // chain accounts for the surviving schedules, so a duplicated or
 // overridden row cannot double-count a lock.
 //
-// This is a pure function, no network and no clock. The balances come
-// from fetch.BootstrapGenesis at startup, so a failure here fails
-// startup instead of surfacing later in a background loop.
+// Pure: no network, no clock. The rows come from the storage, where the
+// startup bootstrap put them, so they are folded fresh on every boot — a fix
+// to the fold reaches an existing database without refetching genesis.
 func NewVestings(balances []gnoland.Balance) ([]Vesting, error) {
 	schedules := make(map[crypto.Address]gnoland.Balance)
 
@@ -129,6 +136,7 @@ type snapshot struct {
 // snapshot keeps serving.
 type Handler struct {
 	client          Client
+	storage         Storage
 	logger          *zap.Logger
 	snapshot        atomic.Pointer[snapshot]
 	denoms          []string
@@ -154,14 +162,6 @@ func WithDenoms(denoms []string) Option {
 	}
 }
 
-// WithVestings sets the genesis vesting accounts, from NewVestings over the
-// bootstrap's genesis balances.
-func WithVestings(vestings []Vesting) Option {
-	return func(h *Handler) {
-		h.vestings = vestings
-	}
-}
-
 // WithRefreshInterval overrides how often the snapshot is rebuilt.
 func WithRefreshInterval(interval time.Duration) Option {
 	return func(h *Handler) {
@@ -176,9 +176,10 @@ func WithComputeTimeout(timeout time.Duration) Option {
 	}
 }
 
-func NewHandler(client Client, opts ...Option) *Handler {
+func NewHandler(client Client, store Storage, opts ...Option) *Handler {
 	h := &Handler{
 		client:          client,
+		storage:         store,
 		logger:          zap.NewNop(),
 		refreshInterval: defaultRefreshInterval,
 		computeTimeout:  defaultComputeTimeout,
@@ -194,6 +195,10 @@ func NewHandler(client Client, opts ...Option) *Handler {
 // Start runs the handler's own schedule, refreshing the snapshot on a
 // ticker. Blocks until ctx is done.
 func (h *Handler) Start(ctx context.Context) error {
+	if err := h.loadVestings(); err != nil {
+		return fmt.Errorf("unable to load the genesis vesting schedules: %w", err)
+	}
+
 	ticker := time.NewTicker(h.refreshInterval)
 	defer ticker.Stop()
 
@@ -210,6 +215,26 @@ func (h *Handler) Start(ctx context.Context) error {
 		case <-ticker.C:
 		}
 	}
+}
+
+// loadVestings reads the genesis balance rows the bootstrap stored and folds
+// them into the vesting accounts the locked math needs.
+func (h *Handler) loadVestings() error {
+	balances, err := h.storage.GetGenesisBalances()
+	if err != nil {
+		return fmt.Errorf("unable to read the genesis balances: %w", err)
+	}
+
+	vestings, err := NewVestings(balances)
+	if err != nil {
+		return err
+	}
+
+	h.vestings = vestings
+
+	h.logger.Info("Loaded the genesis vesting schedules", zap.Int("count", len(vestings)))
+
+	return nil
 }
 
 // GetSupply returns the supply of denom split into total, spendable and

--- a/serve/handlers/supply/supply_test.go
+++ b/serve/handlers/supply/supply_test.go
@@ -40,8 +40,8 @@ type mockClient struct {
 // mockStorage serves the genesis balance rows the startup bootstrap would have
 // written. errBalances, when set, fails the read.
 type mockStorage struct {
-	balances    []gnoland.Balance
 	errBalances error
+	balances    []gnoland.Balance
 }
 
 func (m *mockStorage) GetGenesisBalances() ([]gnoland.Balance, error) {

--- a/serve/handlers/supply/supply_test.go
+++ b/serve/handlers/supply/supply_test.go
@@ -3,6 +3,7 @@ package supply
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -34,6 +35,21 @@ type (
 type mockClient struct {
 	batchQueryFn batchQueryDelegate
 	getStatusFn  getStatusDelegate
+}
+
+// mockStorage serves the genesis balance rows the startup bootstrap would have
+// written. errBalances, when set, fails the read.
+type mockStorage struct {
+	balances    []gnoland.Balance
+	errBalances error
+}
+
+func (m *mockStorage) GetGenesisBalances() ([]gnoland.Balance, error) {
+	if m.errBalances != nil {
+		return nil, m.errBalances
+	}
+
+	return m.balances, nil
 }
 
 func (m *mockClient) GetStatus(ctx context.Context) (*core_types.ResultStatus, error) {
@@ -231,19 +247,22 @@ func abciError(err error) *core_types.ResultABCIQuery {
 	}
 }
 
-// newHandler builds a handler over the fixture with the given genesis rows,
-// folding them the way the startup bootstrap does.
+// newHandler builds a handler over the fixture, with the given genesis rows
+// waiting in the storage the way the startup bootstrap leaves them.
 func newHandler(t *testing.T, f *chainFixture, balances ...gnoland.Balance) *Handler {
 	t.Helper()
 
-	vestings, err := NewVestings(balances)
-	require.NoError(t, err)
-
-	return NewHandler(
+	h := NewHandler(
 		f.client(),
+		&mockStorage{balances: balances},
 		WithDenoms([]string{testDenom}),
-		WithVestings(vestings),
 	)
+
+	// Start loads the schedules before serving; these tests drive refresh
+	// directly, so they do the same.
+	require.NoError(t, h.loadVestings())
+
+	return h
 }
 
 // ---------------------------------------------------------------
@@ -493,10 +512,8 @@ func TestRefreshHonorsShutdownContext(t *testing.T) {
 		},
 	}
 
-	vestings, err := NewVestings(nil)
-	require.NoError(t, err)
-
-	h := NewHandler(client, WithDenoms([]string{testDenom}), WithVestings(vestings))
+	h := NewHandler(client, &mockStorage{}, WithDenoms([]string{testDenom}))
+	require.NoError(t, h.loadVestings())
 	h.refresh(context.Background())
 
 	before, err := h.GetSupply(context.Background(), testDenom)
@@ -537,6 +554,25 @@ func TestStartRefreshesImmediately(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "a snapshot must exist before the first tick")
 
 	cancel()
+}
+
+// The bootstrap commits the balances before any service starts, so a storage
+// that cannot serve them is corrupt. Start fails rather than serving a supply
+// with no vesting schedules, which would report everything as circulating.
+func TestStartFailsOnUnreadableVestings(t *testing.T) {
+	t.Parallel()
+
+	fixture := newChainFixture()
+	readErr := errors.New("genesis balances missing")
+
+	h := NewHandler(
+		fixture.client(),
+		&mockStorage{errBalances: readErr},
+		WithDenoms([]string{testDenom}),
+	)
+
+	require.ErrorIs(t, h.Start(context.Background()), readErr)
+	require.Zero(t, fixture.rec.count(), "no refresh must run without the schedules")
 }
 
 // ---------------------------------------------------------------

--- a/storage/encode.go
+++ b/storage/encode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/pkg/errors"
@@ -259,4 +260,26 @@ func decodeTx(encodedTx []byte) (*types.TxResult, error) {
 	}
 
 	return &tx, nil
+}
+
+// genesisBalances wraps the rows so amino has a struct to work with, and so
+// the record can gain fields later without breaking what is already on disk.
+type genesisBalances struct {
+	Balances []gnoland.Balance
+}
+
+// encodeGenesisBalances encodes the genesis balance rows in Amino binary
+func encodeGenesisBalances(balances []gnoland.Balance) ([]byte, error) {
+	return amino.Marshal(genesisBalances{Balances: balances})
+}
+
+// decodeGenesisBalances decodes the Amino encoded genesis balance rows
+func decodeGenesisBalances(encodedBalances []byte) ([]gnoland.Balance, error) {
+	var wrapped genesisBalances
+
+	if err := amino.Unmarshal(encodedBalances, &wrapped); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal Amino genesis balances, %w", err)
+	}
+
+	return wrapped.Balances, nil
 }

--- a/storage/pebble.go
+++ b/storage/pebble.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 	"go.uber.org/multierr"
 
@@ -17,6 +18,14 @@ const (
 	// keyLatestHeight is the quick lookup key
 	// for the latest height saved in the DB
 	keyLatestHeight = "/meta/lh"
+
+	// keyGenesisChainID is the chain ID of the bootstrapped genesis. Kept
+	// apart from the balances so the bootstrap can check for a completed
+	// genesis without decoding them
+	keyGenesisChainID = "/meta/genesis/chainid"
+
+	// keyGenesisBalances holds the genesis balance rows, unfolded
+	keyGenesisBalances = "/meta/genesis/balances"
 
 	// prefixKeyBlocks is the key for each block saved. They are stored by height
 	prefixKeyBlocks = "/data/blocks/"
@@ -94,6 +103,40 @@ func (s *Pebble) GetLatestHeight() (uint64, error) {
 	_, val, err := decodeUint64Ascending(height)
 
 	return val, err
+}
+
+// GetGenesisChainID fetches the chain ID of the bootstrapped genesis, if any
+func (s *Pebble) GetGenesisChainID() (string, error) {
+	chainID, c, err := s.db.Get([]byte(keyGenesisChainID))
+	if errors.Is(err, pebble.ErrNotFound) {
+		return "", storageErrors.ErrNotFound
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	defer c.Close()
+
+	// Stored raw: a chain ID is a string, and amino would only add a header
+	// to a value the bootstrap reads on every startup.
+	return string(chainID), nil
+}
+
+// GetGenesisBalances fetches the genesis balance rows from storage, if any
+func (s *Pebble) GetGenesisBalances() ([]gnoland.Balance, error) {
+	balances, c, err := s.db.Get([]byte(keyGenesisBalances))
+	if errors.Is(err, pebble.ErrNotFound) {
+		return nil, storageErrors.ErrNotFound
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer c.Close()
+
+	return decodeGenesisBalances(balances)
 }
 
 // GetBlock fetches the specified block from storage, if any
@@ -494,6 +537,19 @@ func (b *PebbleBatch) SetLatestHeight(h uint64) error {
 	val = encodeUint64Ascending(val, h)
 
 	return b.b.Set([]byte(keyLatestHeight), val, pebble.NoSync)
+}
+
+func (b *PebbleBatch) SetGenesisBalances(balances []gnoland.Balance) error {
+	eb, err := encodeGenesisBalances(balances)
+	if err != nil {
+		return err
+	}
+
+	return b.b.Set([]byte(keyGenesisBalances), eb, pebble.NoSync)
+}
+
+func (b *PebbleBatch) SetGenesisChainID(chainID string) error {
+	return b.b.Set([]byte(keyGenesisChainID), []byte(chainID), pebble.NoSync)
 }
 
 func (b *PebbleBatch) SetBlock(block *types.Block) error {

--- a/storage/pebble_test.go
+++ b/storage/pebble_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,6 +52,74 @@ func TestStorage_LatestHeight(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, i, latest)
 	}
+}
+
+func TestStorage_GenesisChainID(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewPebble(t.TempDir())
+	require.NoError(t, err)
+
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+
+	// The chain ID is written last, so its absence is what tells the bootstrap
+	// there is work to do.
+	chainID, err := s.GetGenesisChainID()
+	require.ErrorIs(t, err, storageErrors.ErrNotFound)
+	require.Empty(t, chainID)
+
+	b := s.WriteBatch()
+	require.NoError(t, b.SetGenesisChainID("test-chain"))
+	require.NoError(t, b.Commit())
+
+	chainID, err = s.GetGenesisChainID()
+	require.NoError(t, err)
+	require.Equal(t, "test-chain", chainID)
+}
+
+func TestStorage_GenesisBalances(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewPebble(t.TempDir())
+	require.NoError(t, err)
+
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+
+	balances, err := s.GetGenesisBalances()
+	require.ErrorIs(t, err, storageErrors.ErrNotFound)
+	require.Nil(t, balances)
+
+	addr := crypto.MustAddressFromString("g1u7y667z64x2h7vc6fmpcprgey4ck233jaww9zq")
+
+	saved := []gnoland.Balance{
+		// A plain row and a vesting row: Vesting is a pointer field, so this
+		// also pins down that amino round-trips the schedule.
+		{
+			Address: addr,
+			Amount:  std.MustParseCoins("1000ugnot"),
+		},
+		{
+			Address: addr,
+			Amount:  std.MustParseCoins("2000ugnot"),
+			Vesting: &std.VestingSchedule{
+				OriginalVesting: std.MustParseCoins("2000ugnot"),
+				StartTime:       100,
+				EndTime:         200,
+			},
+		},
+	}
+
+	b := s.WriteBatch()
+	require.NoError(t, b.SetGenesisBalances(saved))
+	require.NoError(t, b.Commit())
+
+	balances, err = s.GetGenesisBalances()
+	require.NoError(t, err)
+	require.Equal(t, saved, balances)
 }
 
 func TestStorage_Block(t *testing.T) {

--- a/storage/types.go
+++ b/storage/types.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"io"
 
+	"github.com/gnolang/gno/gno.land/pkg/gnoland"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
 )
 
@@ -18,6 +19,15 @@ type Reader interface {
 	io.Closer
 	// GetLatestHeight returns the latest block height from the storage
 	GetLatestHeight() (uint64, error)
+
+	// GetGenesisChainID returns the chain ID of the bootstrapped genesis, or
+	// ErrNotFound if the genesis has not been fully bootstrapped into this
+	// storage. It is written last, so its presence marks the bootstrap done —
+	// which is why the completion check never has to decode the balances
+	GetGenesisChainID() (string, error)
+
+	// GetGenesisBalances returns the stored genesis balance rows, unfolded
+	GetGenesisBalances() ([]gnoland.Balance, error)
 
 	// GetBlock fetches the block by its number
 	GetBlock(uint64) (*types.Block, error)
@@ -62,6 +72,11 @@ type Writer interface {
 type Batch interface {
 	// SetLatestHeight saves the latest block height to the storage
 	SetLatestHeight(uint64) error
+	// SetGenesisBalances saves the genesis balance rows to the permanent storage
+	SetGenesisBalances(balances []gnoland.Balance) error
+	// SetGenesisChainID saves the genesis chain ID. It marks the bootstrap
+	// complete, so it must be committed after everything else genesis writes
+	SetGenesisChainID(chainID string) error
 	// SetBlock saves the block to the permanent storage
 	SetBlock(block *types.Block) error
 	// SetTx saves the transaction to the permanent storage


### PR DESCRIPTION
The genesis document was fetched and decoded on every startup, and the
genesis block was rebuilt — marshalling every genesis tx — before the
storage check decided it was not needed. Both costs sat on the critical
path before indexing could resume.

The balances are the reason the document had to be refetched at all, so
persist them: genesis is now loaded once per database, and every later
start reads what it needs from storage without touching the node.

Move the bootstrap out of the fetcher into its own package. It served two
consumers and belonged to neither, and the fetcher's Client no longer
needs GetGenesis or GetStatus. Writing block 0 through the batch directly
rather than through writeSlot also means a block that cannot be stored
fails the bootstrap instead of being logged and skipped — that tolerance
exists so one bad legacy block cannot stop the fetcher, but here it would
leave block 0 permanently missing.

Storage gains two keys rather than one record. The chain ID is written
last, so its presence marks the bootstrap complete and the completion
check never has to decode the balances. The balances are stored unfolded,
so a future fix to the fold reaches an existing database without
refetching genesis. Everything commits in one batch, so there is no
half-bootstrapped state to reason about.

The supply handler reads its own balances from storage instead of having
them threaded down from main.

Two behaviour changes, documented in the README:

- The indexer refuses to start if it cannot bootstrap the genesis. It
  retries while the node is unreachable, and fails outright against a
  node that does not serve a readable gno genesis.
- The chain ID is checked against the node on every start, so reusing a
  database across networks refuses to start rather than mixing two