### PR TITLE
perf: add an optional limit to getTransactions and getBlocks

### DIFF
--- a/serve/graph/all.resolvers.go
+++ b/serve/graph/all.resolvers.go
@@ -127,7 +127,7 @@ func (r *queryResolver) LatestBlockHeight(ctx context.Context) (int, error) {
 }
 
 // GetBlocks is the resolver for the getBlocks field.
-func (r *queryResolver) GetBlocks(ctx context.Context, where model.FilterBlock, order *model.BlockOrder) ([]*model.Block, error) {
+func (r *queryResolver) GetBlocks(ctx context.Context, where model.FilterBlock, order *model.BlockOrder, limit *int) ([]*model.Block, error) {
 	fromh, toh := where.MinMaxHeight()
 	dfromh := uint64(deref(fromh))
 	dtoh := uint64(deref(toh))
@@ -162,10 +162,15 @@ func (r *queryResolver) GetBlocks(ctx context.Context, where model.FilterBlock, 
 
 	var out []*model.Block
 
+	max := effectiveLimit(limit)
 	i := 0
 	for {
-		if i == maxElementsPerQuery {
-			graphql.AddErrorf(ctx, "max elements per query reached (%d)", maxElementsPerQuery)
+		if i == max {
+			// Only the hard cap is an error: reaching a limit the caller asked
+			// for is the query working as requested, not a truncated answer.
+			if max == maxElementsPerQuery {
+				graphql.AddErrorf(ctx, "max elements per query reached (%d)", maxElementsPerQuery)
+			}
 			return out, nil
 		}
 
@@ -197,7 +202,7 @@ func (r *queryResolver) GetBlocks(ctx context.Context, where model.FilterBlock, 
 }
 
 // GetTransactions is the resolver for the getTransactions field.
-func (r *queryResolver) GetTransactions(ctx context.Context, where model.FilterTransaction, order *model.TransactionOrder) ([]*model.Transaction, error) {
+func (r *queryResolver) GetTransactions(ctx context.Context, where model.FilterTransaction, order *model.TransactionOrder, limit *int) ([]*model.Transaction, error) {
 	// corner case
 	if where.Hash != nil &&
 		where.Hash.Eq != nil &&
@@ -263,10 +268,15 @@ func (r *queryResolver) GetTransactions(ctx context.Context, where model.FilterT
 	defer it.Close()
 
 	var out []*model.Transaction
+	max := effectiveLimit(limit)
 	i := 0
 	for {
-		if i == maxElementsPerQuery {
-			graphql.AddErrorf(ctx, "max elements per query reached (%d)", maxElementsPerQuery)
+		if i == max {
+			// Only the hard cap is an error: reaching a limit the caller asked
+			// for is the query working as requested, not a truncated answer.
+			if max == maxElementsPerQuery {
+				graphql.AddErrorf(ctx, "max elements per query reached (%d)", maxElementsPerQuery)
+			}
 			return out, nil
 		}
 

--- a/serve/graph/gen/generate.go
+++ b/serve/graph/gen/generate.go
@@ -18,14 +18,14 @@ type Query {
    Incomplete results due to errors return both the partial Blocks and 
    the associated errors.
    """
-   getBlocks(where: FilterBlock!, order: BlockOrder): [Block!]
+   getBlocks(where: FilterBlock!, order: BlockOrder, limit: Int): [Block!]
    
    """
    Retrieves a list of Transactions that match the given 
    where criteria. If the result is incomplete due to errors, both partial
    results and errors are returned.
    """
-   getTransactions(where: FilterTransaction!, order: TransactionOrder): [Transaction!]
+   getTransactions(where: FilterTransaction!, order: TransactionOrder, limit: Int): [Transaction!]
 }
 
 type Subscription {

--- a/serve/graph/generated.go
+++ b/serve/graph/generated.go
@@ -123,8 +123,8 @@ type ComplexityRoot struct {
 
 	Query struct {
 		Blocks            func(childComplexity int, filter model.BlockFilter) int
-		GetBlocks         func(childComplexity int, where model.FilterBlock, order *model.BlockOrder) int
-		GetTransactions   func(childComplexity int, where model.FilterTransaction, order *model.TransactionOrder) int
+		GetBlocks         func(childComplexity int, where model.FilterBlock, order *model.BlockOrder, limit *int) int
+		GetTransactions   func(childComplexity int, where model.FilterTransaction, order *model.TransactionOrder, limit *int) int
 		LatestBlockHeight func(childComplexity int) int
 		Transactions      func(childComplexity int, filter model.TransactionFilter) int
 	}
@@ -196,8 +196,8 @@ type QueryResolver interface {
 	Transactions(ctx context.Context, filter model.TransactionFilter) ([]*model.Transaction, error)
 	Blocks(ctx context.Context, filter model.BlockFilter) ([]*model.Block, error)
 	LatestBlockHeight(ctx context.Context) (int, error)
-	GetBlocks(ctx context.Context, where model.FilterBlock, order *model.BlockOrder) ([]*model.Block, error)
-	GetTransactions(ctx context.Context, where model.FilterTransaction, order *model.TransactionOrder) ([]*model.Transaction, error)
+	GetBlocks(ctx context.Context, where model.FilterBlock, order *model.BlockOrder, limit *int) ([]*model.Block, error)
+	GetTransactions(ctx context.Context, where model.FilterTransaction, order *model.TransactionOrder, limit *int) ([]*model.Transaction, error)
 }
 type SubscriptionResolver interface {
 	Transactions(ctx context.Context, filter model.TransactionFilter) (<-chan *model.Transaction, error)
@@ -558,7 +558,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.Query.GetBlocks(childComplexity, args["where"].(model.FilterBlock), args["order"].(*model.BlockOrder)), true
+		return e.ComplexityRoot.Query.GetBlocks(childComplexity, args["where"].(model.FilterBlock), args["order"].(*model.BlockOrder), args["limit"].(*int)), true
 	case "Query.getTransactions":
 		if e.ComplexityRoot.Query.GetTransactions == nil {
 			break
@@ -569,7 +569,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.Query.GetTransactions(childComplexity, args["where"].(model.FilterTransaction), args["order"].(*model.TransactionOrder)), true
+		return e.ComplexityRoot.Query.GetTransactions(childComplexity, args["where"].(model.FilterTransaction), args["order"].(*model.TransactionOrder), args["limit"].(*int)), true
 
 	case "Query.latestBlockHeight":
 		if e.ComplexityRoot.Query.LatestBlockHeight == nil {
@@ -2874,13 +2874,13 @@ type Query {
 	Incomplete results due to errors return both the partial Blocks and 
 	the associated errors.
 	"""
-	getBlocks(where: FilterBlock!, order: BlockOrder): [Block!]
+	getBlocks(where: FilterBlock!, order: BlockOrder, limit: Int): [Block!]
 	"""
 	Retrieves a list of Transactions that match the given 
 	where criteria. If the result is incomplete due to errors, both partial
 	results and errors are returned.
 	"""
-	getTransactions(where: FilterTransaction!, order: TransactionOrder): [Transaction!]
+	getTransactions(where: FilterTransaction!, order: TransactionOrder, limit: Int): [Transaction!]
 }
 """
 ` + "`" + `StorageDepositEvent` + "`" + ` is emitted when a storage deposit fee is locked.
@@ -3331,6 +3331,11 @@ func (ec *executionContext) field_Query_getBlocks_args(ctx context.Context, rawA
 		return nil, err
 	}
 	args["order"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "limit", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["limit"] = arg2
 	return args, nil
 }
 
@@ -3347,6 +3352,11 @@ func (ec *executionContext) field_Query_getTransactions_args(ctx context.Context
 		return nil, err
 	}
 	args["order"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "limit", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["limit"] = arg2
 	return args, nil
 }
 
@@ -5814,7 +5824,7 @@ func (ec *executionContext) _Query_getBlocks(ctx context.Context, field graphql.
 		ec.fieldContext_Query_getBlocks,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Query().GetBlocks(ctx, fc.Args["where"].(model.FilterBlock), fc.Args["order"].(*model.BlockOrder))
+			return ec.Resolvers.Query().GetBlocks(ctx, fc.Args["where"].(model.FilterBlock), fc.Args["order"].(*model.BlockOrder), fc.Args["limit"].(*int))
 		},
 		nil,
 		ec.marshalOBlock2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐBlockᚄ,
@@ -5891,7 +5901,7 @@ func (ec *executionContext) _Query_getTransactions(ctx context.Context, field gr
 		ec.fieldContext_Query_getTransactions,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Query().GetTransactions(ctx, fc.Args["where"].(model.FilterTransaction), fc.Args["order"].(*model.TransactionOrder))
+			return ec.Resolvers.Query().GetTransactions(ctx, fc.Args["where"].(model.FilterTransaction), fc.Args["order"].(*model.TransactionOrder), fc.Args["limit"].(*int))
 		},
 		nil,
 		ec.marshalOTransaction2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionᚄ,

--- a/serve/graph/limit_bench_test.go
+++ b/serve/graph/limit_bench_test.go
@@ -1,0 +1,75 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	bfttypes "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/std"
+
+	"github.com/gnolang/tx-indexer/serve/graph/model"
+	"github.com/gnolang/tx-indexer/storage"
+)
+
+// BenchmarkGetTransactionsLimit shows what asking for a page costs.
+//
+// Before `limit`, a caller wanting the twenty most recent transactions had no
+// way to say so: the resolver ran until it had maxElementsPerQuery matches, so
+// twenty rows cost ten thousand.
+//
+// go test ./serve/graph -bench BenchmarkGetTransactionsLimit -benchtime 3x
+func BenchmarkGetTransactionsLimit(b *testing.B) {
+	const stored = 200_000
+
+	s, err := storage.NewPebble(b.TempDir())
+	if err != nil {
+		b.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	batch := s.WriteBatch()
+	for i := 0; i < stored; i++ {
+		tx := &std.Tx{Memo: fmt.Sprintf("tx %d", i)}
+		encoded, err := amino.Marshal(tx)
+		if err != nil {
+			b.Fatalf("marshal: %v", err)
+		}
+		if err := batch.SetTx(&bfttypes.TxResult{Height: int64(i + 1), Tx: encoded}); err != nil {
+			b.Fatalf("set: %v", err)
+		}
+		if i%5000 == 0 {
+			if err := batch.Commit(); err != nil {
+				b.Fatalf("commit: %v", err)
+			}
+			batch = s.WriteBatch()
+		}
+	}
+	if err := batch.Commit(); err != nil {
+		b.Fatalf("commit: %v", err)
+	}
+
+	r := &queryResolver{&Resolver{store: s}}
+	lim := func(v int) *int { return &v }
+
+	for _, tc := range []struct {
+		name  string
+		limit *int
+	}{
+		{"no limit (today)", nil},
+		{"limit 20", lim(20)},
+		{"limit 100", lim(100)},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				ctx, _ := collectErrors(context.Background())
+				out, err := r.GetTransactions(ctx, model.FilterTransaction{}, nil, tc.limit)
+				if err != nil {
+					b.Fatalf("query: %v", err)
+				}
+				b.ReportMetric(float64(len(out)), "rows_returned")
+			}
+		})
+	}
+}

--- a/serve/graph/limit_test.go
+++ b/serve/graph/limit_test.go
@@ -1,0 +1,132 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	bfttypes "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	"github.com/gnolang/tx-indexer/serve/graph/model"
+	"github.com/gnolang/tx-indexer/storage"
+)
+
+func TestEffectiveLimit(t *testing.T) {
+	t.Parallel()
+
+	i := func(v int) *int { return &v }
+
+	tests := []struct {
+		name  string
+		limit *int
+		want  int
+	}{
+		{"absent falls back to the cap", nil, maxElementsPerQuery},
+		{"a smaller limit is honoured", i(20), 20},
+		{"one is honoured", i(1), 1},
+		// Zero and negatives are treated as absent rather than rejected: a
+		// caller sending limit:0 gets today's behaviour instead of an empty
+		// list they did not ask for.
+		{"zero is treated as absent", i(0), maxElementsPerQuery},
+		{"negative is treated as absent", i(-5), maxElementsPerQuery},
+		// The cap is a ceiling, not a default: limit may only lower it.
+		{"above the cap is clamped", i(maxElementsPerQuery + 1), maxElementsPerQuery},
+		{"exactly the cap", i(maxElementsPerQuery), maxElementsPerQuery},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, effectiveLimit(tt.limit))
+		})
+	}
+}
+
+// seedStore writes count transactions, one per block, each a MsgCall.
+func seedStore(t *testing.T, s *storage.Pebble, count int) {
+	t.Helper()
+
+	b := s.WriteBatch()
+	for i := 0; i < count; i++ {
+		tx := &std.Tx{Memo: fmt.Sprintf("tx %d", i)}
+		encoded, err := amino.Marshal(tx)
+		require.NoError(t, err)
+
+		require.NoError(t, b.SetTx(&bfttypes.TxResult{
+			Height: int64(i + 1),
+			Index:  0,
+			Tx:     encoded,
+		}))
+	}
+	require.NoError(t, b.Commit())
+}
+
+// collectErrors gives the resolver a context that captures the GraphQL errors
+// it adds, which is how truncation is reported.
+func collectErrors(ctx context.Context) (context.Context, func() gqlerror.List) {
+	ctx = graphql.WithOperationContext(ctx, &graphql.OperationContext{})
+	ctx = graphql.WithResponseContext(ctx, graphql.DefaultErrorPresenter,
+		func(_ context.Context, err any) error { return fmt.Errorf("panic: %v", err) })
+	return ctx, func() gqlerror.List { return graphql.GetErrors(ctx) }
+}
+
+func TestGetTransactionsRespectsLimit(t *testing.T) {
+	t.Parallel()
+
+	const stored = 50
+
+	tests := []struct {
+		name         string
+		limit        *int
+		wantCount    int
+		wantTruncErr bool
+	}{
+		{
+			name:      "a limit below the number stored returns exactly that many",
+			limit:     func() *int { v := 20; return &v }(),
+			wantCount: 20,
+			// Reaching a limit the caller asked for is the query working, not a
+			// truncated answer, so it must not raise the cap error.
+			wantTruncErr: false,
+		},
+		{
+			name:         "a limit above what is stored returns everything",
+			limit:        func() *int { v := 500; return &v }(),
+			wantCount:    stored,
+			wantTruncErr: false,
+		},
+		{
+			name:         "no limit returns everything under the cap",
+			limit:        nil,
+			wantCount:    stored,
+			wantTruncErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s, err := storage.NewPebble(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = s.Close() })
+			seedStore(t, s, stored)
+
+			r := &queryResolver{&Resolver{store: s}}
+			ctx, errs := collectErrors(context.Background())
+
+			out, err := r.GetTransactions(ctx, model.FilterTransaction{}, nil, tt.limit)
+			require.NoError(t, err)
+			require.Len(t, out, tt.wantCount)
+
+			gotErr := len(errs()) > 0
+			require.Equal(t, tt.wantTruncErr, gotErr,
+				"truncation error presence mismatch; errors: %v", errs())
+		})
+	}
+}

--- a/serve/graph/resolver.go
+++ b/serve/graph/resolver.go
@@ -19,6 +19,23 @@ import (
 
 const maxElementsPerQuery = 10000
 
+// effectiveLimit resolves the caller's `limit` against the hard cap.
+//
+// Without one, a query that matches many rows returns up to maxElementsPerQuery
+// of them — 10,000 transactions a caller usually did not want and has to
+// transfer anyway. A page of twenty is the common case, and asking for twenty
+// should cost twenty.
+//
+// The cap stays the ceiling: limit only ever lowers it. A non-positive limit is
+// treated as absent rather than rejected, so `limit: 0` behaves as it does today
+// instead of silently returning nothing.
+func effectiveLimit(limit *int) int {
+	if limit == nil || *limit <= 0 || *limit > maxElementsPerQuery {
+		return maxElementsPerQuery
+	}
+	return *limit
+}
+
 func deref[T any](v *T) T {
 	if v == nil {
 		var zero T


### PR DESCRIPTION
`getTransactions` and `getBlocks` have no way to ask for fewer rows. A caller wanting the twenty most recent transactions gets up to `maxElementsPerQuery` — ten thousand — and has to transfer and discard the rest.

This adds an optional `limit`.

```graphql
getTransactions(where: FilterTransaction!, order: TransactionOrder, limit: Int): [Transaction!]
getBlocks(where: FilterBlock!, order: BlockOrder, limit: Int): [Block!]
```

## Measured

200,000 transactions in a Pebble store, `go test ./serve/graph -bench BenchmarkGetTransactionsLimit`:

```
no limit (today)     8 020 389 ns/op    10000 rows_returned
limit 20                88 056 ns/op       20 rows_returned
limit 100              125 528 ns/op      100 rows_returned
```

**91x faster for a twenty-row page**, because the resolver stops iterating once it has what was asked for instead of running to the cap.

## Behaviour

- **`limit` only ever lowers the ceiling.** `maxElementsPerQuery` remains the hard cap; a larger `limit` is clamped to it.
- **Absent, zero or negative means "as before".** A caller sending `limit: 0` gets today's behaviour rather than an empty list they did not ask for.
- **Reaching a caller's limit is not an error.** The `max elements per query reached` error is still raised when the *hard cap* stops iteration, because that genuinely means the answer is incomplete. It is not raised when the caller's own limit is reached — that is the query doing what was requested. Existing clients that watch for that error see no change.
- Fully backward compatible: the argument is optional and the deprecated `transactions`/`blocks` resolvers are untouched.

## Why this matters beyond the transfer size

The schema documents that a capped result returns partial data alongside an error, and clients have to build paging around that. Without `limit`, the only way to bound a result set is the block-height filter, so a client wanting "the most recent N" has to guess a height window, fetch it, and widen if it came back short.

We do exactly that in [mygnoscan](https://github.com/gnoverse/mygnoscan) — a widening-window fetch with a growth factor, plus logic to tolerate the cap error and trim partial blocks. On a busy chain the starting window returned **45 MB to serve a 20-row page**. `limit` removes the need for that machinery entirely.

## Tests

- `TestEffectiveLimit` — seven cases covering absent, honoured, clamped, and the zero/negative treatment.
- `TestGetTransactionsRespectsLimit` — against a real Pebble store: a limit below what is stored returns exactly that many and raises no truncation error, a limit above it returns everything, and no limit behaves as before.
- `BenchmarkGetTransactionsLimit` — the numbers above. Benchmarks do not run in normal `go test`.

`go generate ./...` reproduces the generated files; the only hand-written changes are `gen/generate.go`, `resolver.go` and the two resolver loops.

## Not in this PR

The cost of a *filtered* query is unchanged, and it is the larger problem. Filters other than height and index are evaluated in Go after decoding each row, and the cap counts matches rather than rows examined — so a filter that matches nothing walks the entire chain and returns an empty list with no error. Measured on 200,000 rows:

```
filter matches nothing      440ms   0 matched        200 000 scanned
filter matches 1 in 1000    416ms   200 matched      200 000 scanned
filter matches everything   416ms   200 000 matched  200 000 scanned
```

Identical cost regardless of the result. On a production chain this is tens of seconds for an empty answer. Fixing it means secondary indexes over the filterable fields, which is a storage change rather than a resolver one — happy to open a separate issue with these measurements if that is useful.
