### PR TITLE
fix: keep an undecodable transaction distinguishable from an empty one

### DIFF
--- a/serve/graph/model/transaction.go
+++ b/serve/graph/model/transaction.go
@@ -97,7 +97,13 @@ func (t *Transaction) getStdTx() *std.Tx {
 	unmarshalTx := func() {
 		var stdTx std.Tx
 		if err := amino.Unmarshal(t.txResult.Tx, &stdTx); err != nil {
-			t.stdTx = nil
+			// Leave t.stdTx nil so callers can tell the payload apart from a
+			// transaction that genuinely carries nothing. The assignment used to
+			// be here, followed unconditionally by the one below, so it was dead:
+			// an undecodable transaction ended up pointing at a zero std.Tx and
+			// reported a zero gas fee, no memo and no messages as though those
+			// were facts about the chain.
+			return
 		}
 
 		t.mu.Lock()
@@ -114,6 +120,16 @@ func (t *Transaction) getMessages() []*TransactionMessage {
 	// Functions that unmarshal transaction messages are executed once.
 	unmarshalMessages := func() {
 		stdTx := t.getStdTx()
+		if stdTx == nil {
+			// Reachable now that a failed decode really does leave this nil.
+			// Memo and GasFee already guarded for it; this did not.
+			t.mu.Lock()
+			t.messages = []*TransactionMessage{}
+			t.mu.Unlock()
+
+			return
+		}
+
 		messages := make([]*TransactionMessage, 0, len(stdTx.GetMsgs()))
 
 		for _, message := range stdTx.GetMsgs() {

--- a/serve/graph/model/transaction_decode_test.go
+++ b/serve/graph/model/transaction_decode_test.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/gnolang/gno/tm2/pkg/amino"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/std"
+	"github.com/stretchr/testify/require"
+)
+
+// A transaction whose payload cannot be decoded must be distinguishable from one
+// that genuinely carries nothing.
+//
+// getStdTx set t.stdTx = nil on a decode error and then overwrote it
+// unconditionally with a pointer to the zero std.Tx, so the nil branch was dead:
+// an undecodable transaction reported a zero gas fee, an empty memo and no
+// messages as though those were facts about the chain, and the nil checks in
+// Memo and GasFee could never fire.
+func TestUndecodableTransaction(t *testing.T) {
+	t.Parallel()
+
+	tx := NewTransaction(&types.TxResult{
+		Height: 1,
+		Tx:     []byte{0xff, 0xfe, 0xfd, 0x00, 0x01},
+	})
+
+	require.Nil(t, tx.GasFee(), "an undecodable payload must not report a fee")
+	require.Empty(t, tx.Memo())
+	// Must not panic: getMessages dereferenced the result of getStdTx without a
+	// nil check, which only became reachable once the nil branch worked.
+	require.Empty(t, tx.Messages())
+}
+
+func TestDecodableTransactionIsUnaffected(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := amino.Marshal(&std.Tx{
+		Fee:  std.Fee{GasFee: std.Coin{Denom: "ugnot", Amount: 42}},
+		Memo: "hello",
+	})
+	require.NoError(t, err)
+
+	tx := NewTransaction(&types.TxResult{Height: 1, Tx: encoded})
+
+	fee := tx.GasFee()
+	require.NotNil(t, fee)
+	require.Equal(t, 42, fee.Amount)
+	require.Equal(t, "ugnot", fee.Denom)
+	require.Equal(t, "hello", tx.Memo())
+}


### PR DESCRIPTION
A transaction whose amino payload cannot be decoded is currently reported as a valid transaction that happens to carry nothing.

```go
unmarshalTx := func() {
    var stdTx std.Tx
    if err := amino.Unmarshal(t.txResult.Tx, &stdTx); err != nil {
        t.stdTx = nil     // dead: overwritten unconditionally below
    }

    t.mu.Lock()
    t.stdTx = &stdTx      // always runs, error or not
    t.mu.Unlock()
}
```

The nil assignment is immediately overwritten, so `getStdTx` never returns nil. `Memo()` and `GasFee()` both check for it, and neither check can ever fire.

Observed before the fix:

```
GasFee() on an undecodable payload = &Coin{Amount:0, Denom:""}
```

A zero fee, an empty memo and no messages are reported as facts about the chain rather than as a decode failure.

## Fix

Return early on the error so `t.stdTx` stays nil, and guard the one consumer that did not expect it.

`getMessages` dereferenced `getStdTx()` directly — harmless while the nil branch was dead, a panic the moment it works. It now returns an empty slice, matching what `Memo` and `GasFee` already did.

Also removes an unsynchronised write: the dead `t.stdTx = nil` was outside the mutex that guards the field.

## Tests

- `TestUndecodableTransaction` — an undecodable payload reports a nil fee, an empty memo, and no messages without panicking. Verified to fail before the change:

  ```
  Error:    Expected nil, but got: &model.Coin{Amount:0, Denom:""}
  Messages: an undecodable payload must not report a fee
  ```

- `TestDecodableTransactionIsUnaffected` — a well-formed transaction still reports its fee and memo, so the early return does not swallow the normal path.

Full suite passes.

## Note

This is a correctness fix rather than a behavioural change anyone is likely to be relying on, but it does mean consumers now see `null` for these fields on a corrupt row instead of zeros. If surfacing the decode error itself would be preferable to a silent nil, that is a bigger change to the GraphQL contract and worth deciding separately — I kept this to making the existing nil checks work as written.
