### PR TITLE
fix(fetch): log missing heights and keep retry policy on chunk refetch

### DIFF
--- a/.github/workflows/app_template.yml
+++ b/.github/workflows/app_template.yml
@@ -1,0 +1,49 @@
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        required: true
+        type: string
+      env:
+        required: true
+        type: string
+    secrets:
+      AWS_IAM_OIDC:
+        required: true
+      PAT_TOKEN:
+        required: true
+      REGION:
+        required: true
+permissions:
+  contents: write
+  id-token: write
+jobs:
+#  build:
+#    name: Go Build
+#    uses: ./.github/workflows/build_template.yml
+#    with:
+#      go-version: '1.22.x'
+#  test:
+#    name: Go Test
+#    uses: ./.github/workflows/test_template.yml
+#    with:
+#      go-version: '1.22.x'
+#      tests-timeout: '30m'
+  docker-build:
+    name: Docker Build
+    uses: ./.github/workflows/docker_build_template.yml
+    with:
+      go-version: '1.23.x'
+      app-name: ${{ inputs.app-name }}
+      env: ${{ inputs.env }}
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      REGION: ${{ secrets.REGION }}
+  helm_chart_push:
+    name: helm chart image tag push
+    uses: ./.github/workflows/helm_chart_push.yml
+    with:
+      app-name: ${{ inputs.app-name }}
+      env: ${{ inputs.env }}
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/app_template.yml
+++ b/.github/workflows/app_template.yml
@@ -7,6 +7,10 @@ on:
       env:
         required: true
         type: string
+      helm-chart-repo:
+        required: true
+        type: string
+        description: 'GitHub repository path for helm chart (e.g., onbloc/onbloc-helm-chart)'
     secrets:
       AWS_IAM_OIDC:
         required: true
@@ -45,5 +49,6 @@ jobs:
     with:
       app-name: ${{ inputs.app-name }}
       env: ${{ inputs.env }}
+      helm-chart-repo: ${{ inputs.helm-chart-repo }}
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/app_template.yml
+++ b/.github/workflows/app_template.yml
@@ -45,6 +45,7 @@ jobs:
       REGION: ${{ secrets.REGION }}
   helm_chart_push:
     name: helm chart image tag push
+    needs: [docker-build]
     uses: ./.github/workflows/helm_chart_push.yml
     with:
       app-name: ${{ inputs.app-name }}

--- a/.github/workflows/app_template.yml
+++ b/.github/workflows/app_template.yml
@@ -18,22 +18,22 @@ permissions:
   contents: write
   id-token: write
 jobs:
-#  build:
-#    name: Go Build
-#    uses: ./.github/workflows/build_template.yml
-#    with:
-#      go-version: '1.22.x'
-#  test:
-#    name: Go Test
-#    uses: ./.github/workflows/test_template.yml
-#    with:
-#      go-version: '1.22.x'
-#      tests-timeout: '30m'
+  #  build:
+  #    name: Go Build
+  #    uses: ./.github/workflows/build_template.yml
+  #    with:
+  #      go-version: '1.22.x'
+  #  test:
+  #    name: Go Test
+  #    uses: ./.github/workflows/test_template.yml
+  #    with:
+  #      go-version: '1.22.x'
+  #      tests-timeout: '30m'
   docker-build:
     name: Docker Build
     uses: ./.github/workflows/docker_build_template.yml
     with:
-      go-version: '1.23.x'
+      go-version: "1.25.9"
       app-name: ${{ inputs.app-name }}
       env: ${{ inputs.env }}
     secrets:

--- a/.github/workflows/app_template.yml
+++ b/.github/workflows/app_template.yml
@@ -10,7 +10,16 @@ on:
       helm-chart-repo:
         required: true
         type: string
-        description: 'GitHub repository path for helm chart (e.g., onbloc/onbloc-helm-chart)'
+        description: 'GitHub repository path for helm chart (e.g., onbloc/onbloc-helm-charts)'
+      helm-branch:
+        required: true
+        type: string
+      network:
+        required: false
+        type: string
+      helm-values-file:
+        required: false
+        type: string
     secrets:
       AWS_IAM_OIDC:
         required: true
@@ -51,5 +60,8 @@ jobs:
       app-name: ${{ inputs.app-name }}
       env: ${{ inputs.env }}
       helm-chart-repo: ${{ inputs.helm-chart-repo }}
+      helm-branch: ${{ inputs.helm-branch }}
+      network: ${{ inputs.network }}
+      helm-values-file: ${{ inputs.helm-values-file }}
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/beta_tx_indexer.yml
+++ b/.github/workflows/beta_tx_indexer.yml
@@ -1,0 +1,22 @@
+name: beta push onbloc-tx-indexer
+
+on:
+  push:
+    branches:
+      - beta
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  main_batch_db_watcher:
+    name: Run tx-indexer app
+    uses: ./.github/workflows/app_template.yml
+    with:
+      app-name: "tx-indexer"
+      env: "gnoswap-beta"
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      REGION: ${{ secrets.DEV_REGION }}

--- a/.github/workflows/beta_tx_indexer.yml
+++ b/.github/workflows/beta_tx_indexer.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "gnoswap-beta"
+      helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/beta_tx_indexer.yml
+++ b/.github/workflows/beta_tx_indexer.yml
@@ -17,6 +17,8 @@ jobs:
       app-name: "tx-indexer"
       env: "gnoswap-beta"
       helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
+      helm-branch: "gnoswap-beta"
+      helm-values-file: "values-gnoswap-beta.yaml"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+
+jobs:
+  generated-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+      - name: Check generated files are up to date
+        run: |
+          go build -o bin/app .

--- a/.github/workflows/dev_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_gnoscan_tx_indexer-v2.yml
@@ -1,0 +1,22 @@
+name: dev gnoscan push onbloc-tx-indexer v2
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  dev_gnoscan_tx_indexer:
+    name: Run tx-indexer app
+    uses: ./.github/workflows/app_template.yml
+    with:
+      app-name: "tx-indexer"
+      env: "dev-gnoscan-v2"
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      REGION: ${{ secrets.DEV_REGION_V2 }}

--- a/.github/workflows/dev_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_gnoscan_tx_indexer-v2.yml
@@ -1,9 +1,6 @@
 name: dev gnoscan push onbloc-tx-indexer v2
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -16,6 +13,7 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "dev-gnoscan-v2"
+      helm-chart-repo: "onbloc/onbloc-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/dev_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_gnoscan_tx_indexer-v2.yml
@@ -13,7 +13,9 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "dev-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      helm-chart-repo: "onbloc/onbloc-helm-charts"
+      helm-branch: "dev"
+      network: "mainnet"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/dev_gnoswap_tx_indexer-v2.yml
+++ b/.github/workflows/dev_gnoswap_tx_indexer-v2.yml
@@ -1,22 +1,19 @@
-name: dev stage gnoscan push onbloc-tx-indexer v2
+name: dev gnoswap push gnoswap-tx-indexer v2
 
 on:
-  push:
-    branches:
-      - staging
   workflow_dispatch:
 
 permissions:
   contents: write
   id-token: write
 jobs:
-  dev_stage_gnoscan_tx_indexer:
+  dev_gnoswap_tx_indexer:
     name: Run tx-indexer app
     uses: ./.github/workflows/app_template.yml
     with:
       app-name: "tx-indexer"
-      env: "dev-stage-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      env: "dev-gnoswap-v2"
+      helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/dev_gnoswap_tx_indexer-v2.yml
+++ b/.github/workflows/dev_gnoswap_tx_indexer-v2.yml
@@ -14,6 +14,8 @@ jobs:
       app-name: "tx-indexer"
       env: "dev-gnoswap-v2"
       helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
+      helm-branch: "dev-gnoswap-v2"
+      helm-values-file: "values-dev-gnoswap-v2.yaml"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/dev_gnoswap_tx_indexer-v2.yml
+++ b/.github/workflows/dev_gnoswap_tx_indexer-v2.yml
@@ -13,9 +13,8 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "dev-gnoswap-v2"
-      helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
-      helm-branch: "dev-gnoswap-v2"
-      helm-values-file: "values-dev-gnoswap-v2.yaml"
+      helm-chart-repo: "gnoswap-labs/gnoswap-helm-charts"
+      helm-branch: "dev"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/dev_stage_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_stage_gnoscan_tx_indexer-v2.yml
@@ -1,0 +1,22 @@
+name: dev stage gnoscan push onbloc-tx-indexer v2
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  dev_stage_gnoscan_tx_indexer:
+    name: Run tx-indexer app
+    uses: ./.github/workflows/app_template.yml
+    with:
+      app-name: "tx-indexer"
+      env: "dev-stage-gnoscan-v2"
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      REGION: ${{ secrets.DEV_REGION_V2 }}

--- a/.github/workflows/dev_stage_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_stage_gnoscan_tx_indexer-v2.yml
@@ -16,7 +16,9 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "dev-stage-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      helm-chart-repo: "onbloc/onbloc-helm-charts"
+      helm-branch: "dev"
+      network: "staging"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/dev_testnet_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_testnet_gnoscan_tx_indexer-v2.yml
@@ -1,0 +1,22 @@
+name: dev testnet gnoscan push onbloc-tx-indexer v2
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  dev_testnet_gnoscan_tx_indexer:
+    name: Run tx-indexer app
+    uses: ./.github/workflows/app_template.yml
+    with:
+      app-name: 'tx-indexer'
+      env: 'dev-testnet-gnoscan-v2'
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      REGION: ${{ secrets.DEV_REGION_V2 }}

--- a/.github/workflows/dev_testnet_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_testnet_gnoscan_tx_indexer-v2.yml
@@ -1,9 +1,6 @@
 name: dev testnet gnoscan push onbloc-tx-indexer v2
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -14,8 +11,9 @@ jobs:
     name: Run tx-indexer app
     uses: ./.github/workflows/app_template.yml
     with:
-      app-name: 'tx-indexer'
-      env: 'dev-testnet-gnoscan-v2'
+      app-name: "tx-indexer"
+      env: "dev-testnet-gnoscan-v2"
+      helm-chart-repo: "onbloc/onbloc-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/dev_testnet_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/dev_testnet_gnoscan_tx_indexer-v2.yml
@@ -13,7 +13,9 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "dev-testnet-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      helm-chart-repo: "onbloc/onbloc-helm-charts"
+      helm-branch: "dev"
+      network: "testnet"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/docker_build_template.yml
+++ b/.github/workflows/docker_build_template.yml
@@ -1,0 +1,55 @@
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+      app-name:
+        required: true
+        type: string
+      env:
+        required: true
+        type: string
+    secrets:
+      AWS_IAM_OIDC:
+        required: true
+      REGION:
+        required: true
+
+jobs:
+  generated-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Check generated files are up to date
+        run: |
+          docker build -t ${{ inputs.app-name }}:latest .
+      - name: AWS Set credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_OIDC }}
+          aws-region: ${{ secrets.REGION }}
+
+      - name: Amazon ECR login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker tag
+        run: |
+          docker tag ${{ inputs.app-name }}:latest 249291979454.dkr.ecr.${{ secrets.REGION }}.amazonaws.com/onbloc/${{ inputs.app-name }}-${{ inputs.env}}:latest
+          docker tag ${{ inputs.app-name }}:latest 249291979454.dkr.ecr.${{ secrets.REGION }}.amazonaws.com/onbloc/${{ inputs.app-name }}-${{ inputs.env}}:${{ github.sha }}
+
+      - name: Pushing Docker images to Amazon ECR
+        run: |
+          docker push 249291979454.dkr.ecr.${{ secrets.REGION }}.amazonaws.com/onbloc/${{ inputs.app-name }}-${{ inputs.env}}:latest
+          docker push 249291979454.dkr.ecr.${{ secrets.REGION }}.amazonaws.com/onbloc/${{ inputs.app-name }}-${{ inputs.env}}:${{ github.sha }}

--- a/.github/workflows/helm_chart_push.yml
+++ b/.github/workflows/helm_chart_push.yml
@@ -1,0 +1,50 @@
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        required: true
+        type: string
+      env:
+        required: true
+        type: string
+    secrets:
+      PAT_TOKEN:
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  helm_chart_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repo onbloc-helm-chart
+        run: |
+          echo ${{ secrets.PAT_TOKEN }}
+          git clone https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/onbloc/onbloc-helm-chart.git onbloc-helm-chart
+
+      - name: Make changes to onbloc-helm-chart Repo
+        run: |
+          cd onbloc-helm-chart/
+          git checkout -b deploy-${{ github.run_id }}-${{ inputs.app-name }} origin/${{ inputs.env }}
+          cd ${{ inputs.app-name }}
+          sed -i "s/^\(\s*tag\s*:\s*\).*/\1'${{ github.sha }}'/" values-${{ inputs.env }}.yaml
+
+      - name: Commit and push changes to helm repository
+        run: |
+          cd onbloc-helm-chart/
+          git config --global user.email "gnoswap@onbloc.xyz"
+          git config --global user.name "onbloc"
+          git add .
+          git commit -m "Pushed onbloc-${{ inputs.app-name }}-${{ inputs.env }}:${{ github.sha }}"
+          git push origin deploy-${{ github.run_id }}-${{ inputs.app-name }}
+          git checkout ${{ inputs.env }}
+          git pull --rebase origin deploy-${{ github.run_id }}-${{ inputs.app-name }} || git rebase --abort
+          git push origin ${{ inputs.env }}
+          git branch -d deploy-${{ github.run_id }}-${{ inputs.app-name }}
+          git push origin --delete deploy-${{ github.run_id }}-${{ inputs.app-name }}
+          echo "  ____                     _ "
+          echo " |  _ \  ___  _ __   ___  | |"
+          echo " | | | |/ _ \| '_ \ / _ \ | |"
+          echo " | |_| | (_) | | | |  __/ |_|"
+          echo " |____/ \___/|_| |_|\___| (_)"

--- a/.github/workflows/helm_chart_push.yml
+++ b/.github/workflows/helm_chart_push.yml
@@ -7,6 +7,10 @@ on:
       env:
         required: true
         type: string
+      helm-chart-repo:
+        required: true
+        type: string
+        description: "GitHub repository path for helm chart (e.g., onbloc/onbloc-helm-chart)"
     secrets:
       PAT_TOKEN:
         required: true
@@ -18,25 +22,25 @@ jobs:
   helm_chart_push:
     runs-on: ubuntu-latest
     steps:
-      - name: Clone Repo onbloc-helm-chart
+      - name: Clone Helm Chart Repo
         run: |
           echo ${{ secrets.PAT_TOKEN }}
-          git clone https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/onbloc/onbloc-helm-chart.git onbloc-helm-chart
+          git clone https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ inputs.helm-chart-repo }}.git helm-chart
 
-      - name: Make changes to onbloc-helm-chart Repo
+      - name: Make changes to Helm Chart Repo
         run: |
-          cd onbloc-helm-chart/
+          cd helm-chart/
           git checkout -b deploy-${{ github.run_id }}-${{ inputs.app-name }} origin/${{ inputs.env }}
           cd ${{ inputs.app-name }}
           sed -i "s/^\(\s*tag\s*:\s*\).*/\1'${{ github.sha }}'/" values-${{ inputs.env }}.yaml
 
       - name: Commit and push changes to helm repository
         run: |
-          cd onbloc-helm-chart/
+          cd helm-chart/
           git config --global user.email "gnoswap@onbloc.xyz"
           git config --global user.name "onbloc"
           git add .
-          git commit -m "Pushed onbloc-${{ inputs.app-name }}-${{ inputs.env }}:${{ github.sha }}"
+          git commit -m "Pushed ${{ inputs.app-name }}-${{ inputs.env }}:${{ github.sha }}"
           git push origin deploy-${{ github.run_id }}-${{ inputs.app-name }}
           git checkout ${{ inputs.env }}
           git pull --rebase origin deploy-${{ github.run_id }}-${{ inputs.app-name }} || git rebase --abort

--- a/.github/workflows/helm_chart_push.yml
+++ b/.github/workflows/helm_chart_push.yml
@@ -10,7 +10,19 @@ on:
       helm-chart-repo:
         required: true
         type: string
-        description: "GitHub repository path for helm chart (e.g., onbloc/onbloc-helm-chart)"
+        description: "GitHub repository path for the helm chart (e.g., onbloc/onbloc-helm-charts)"
+      helm-branch:
+        required: true
+        type: string
+        description: "Deploy branch to push the image tag to (e.g., dev, prd)"
+      network:
+        required: false
+        type: string
+        description: "Network for per-network values (mainnet | staging | testnet). Omit for a single values.yaml."
+      helm-values-file:
+        required: false
+        type: string
+        description: "Explicit values file name. Overrides network. Use for charts not following values-<network>.yaml."
     secrets:
       PAT_TOKEN:
         required: true
@@ -22,17 +34,28 @@ jobs:
   helm_chart_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve values file
+        run: |
+          # Target branch and values are passed in explicitly (no env parsing).
+          # Precedence: helm-values-file > values-<network>.yaml > values.yaml
+          if [ -n "${{ inputs.helm-values-file }}" ]; then
+            echo "VALUES_FILE=${{ inputs.helm-values-file }}" >> "$GITHUB_ENV"
+          elif [ -n "${{ inputs.network }}" ]; then
+            echo "VALUES_FILE=values-${{ inputs.network }}.yaml" >> "$GITHUB_ENV"
+          else
+            echo "VALUES_FILE=values.yaml" >> "$GITHUB_ENV"
+          fi
+
       - name: Clone Helm Chart Repo
         run: |
-          echo ${{ secrets.PAT_TOKEN }}
           git clone https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ inputs.helm-chart-repo }}.git helm-chart
 
       - name: Make changes to Helm Chart Repo
         run: |
           cd helm-chart/
-          git checkout -b deploy-${{ github.run_id }}-${{ inputs.app-name }} origin/${{ inputs.env }}
+          git checkout -b deploy-${{ github.run_id }}-${{ inputs.app-name }} origin/${{ inputs.helm-branch }}
           cd ${{ inputs.app-name }}
-          sed -i "s/^\(\s*tag\s*:\s*\).*/\1'${{ github.sha }}'/" values-${{ inputs.env }}.yaml
+          sed -i "s/^\(\s*tag\s*:\s*\).*/\1'${{ github.sha }}'/" "$VALUES_FILE"
 
       - name: Commit and push changes to helm repository
         run: |
@@ -42,9 +65,9 @@ jobs:
           git add .
           git commit -m "Pushed ${{ inputs.app-name }}-${{ inputs.env }}:${{ github.sha }}"
           git push origin deploy-${{ github.run_id }}-${{ inputs.app-name }}
-          git checkout ${{ inputs.env }}
+          git checkout ${{ inputs.helm-branch }}
           git pull --rebase origin deploy-${{ github.run_id }}-${{ inputs.app-name }} || git rebase --abort
-          git push origin ${{ inputs.env }}
+          git push origin ${{ inputs.helm-branch }}
           git branch -d deploy-${{ github.run_id }}-${{ inputs.app-name }}
           git push origin --delete deploy-${{ github.run_id }}-${{ inputs.app-name }}
           echo "  ____                     _ "

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/prd_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_gnoscan_tx_indexer-v2.yml
@@ -1,0 +1,19 @@
+name: prd gnoscan push onbloc-tx-indexer v2
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  prd_gnoscan_tx_indexer:
+    name: Run tx-indexer app
+    uses: ./.github/workflows/app_template.yml
+    with:
+      app-name: "tx-indexer"
+      env: "prd-gnoscan-v2"
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      REGION: ${{ secrets.PRD_REGION_V2 }}

--- a/.github/workflows/prd_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_gnoscan_tx_indexer-v2.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "prd-gnoscan-v2"
+      helm-chart-repo: "onbloc/onbloc-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_gnoscan_tx_indexer-v2.yml
@@ -13,7 +13,9 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "prd-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      helm-chart-repo: "onbloc/onbloc-helm-charts"
+      helm-branch: "prd"
+      network: "mainnet"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_gnoswap_tx_indexer-v2.yml
+++ b/.github/workflows/prd_gnoswap_tx_indexer-v2.yml
@@ -1,23 +1,20 @@
-name: dev stage gnoscan push onbloc-tx-indexer v2
+name: prd gnoswap push gnoswap-tx-indexer v2
 
 on:
-  push:
-    branches:
-      - staging
   workflow_dispatch:
 
 permissions:
   contents: write
   id-token: write
 jobs:
-  dev_stage_gnoscan_tx_indexer:
+  prd_gnoswap_tx_indexer:
     name: Run tx-indexer app
     uses: ./.github/workflows/app_template.yml
     with:
       app-name: "tx-indexer"
-      env: "dev-stage-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      env: "prd-gnoswap-v2"
+      helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-      REGION: ${{ secrets.DEV_REGION_V2 }}
+      REGION: ${{ secrets.PRD_REGION_V2 }}

--- a/.github/workflows/prd_gnoswap_tx_indexer-v2.yml
+++ b/.github/workflows/prd_gnoswap_tx_indexer-v2.yml
@@ -14,6 +14,8 @@ jobs:
       app-name: "tx-indexer"
       env: "prd-gnoswap-v2"
       helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
+      helm-branch: "prd-gnoswap-v2"
+      helm-values-file: "values-prd-gnoswap-v2.yaml"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_gnoswap_tx_indexer-v2.yml
+++ b/.github/workflows/prd_gnoswap_tx_indexer-v2.yml
@@ -13,9 +13,8 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "prd-gnoswap-v2"
-      helm-chart-repo: "gnoswap-labs/gnoswap-helm-chart"
-      helm-branch: "prd-gnoswap-v2"
-      helm-values-file: "values-prd-gnoswap-v2.yaml"
+      helm-chart-repo: "gnoswap-labs/gnoswap-helm-charts"
+      helm-branch: "prd"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_green_gnoswap_tx_indexer-v2.yml
+++ b/.github/workflows/prd_green_gnoswap_tx_indexer-v2.yml
@@ -1,4 +1,4 @@
-name: prd gnoswap push gnoswap-tx-indexer v2
+name: prd-green gnoswap push gnoswap-tx-indexer v2
 
 on:
   workflow_dispatch:
@@ -14,7 +14,7 @@ jobs:
       app-name: "tx-indexer"
       env: "prd-gnoswap-v2"
       helm-chart-repo: "gnoswap-labs/gnoswap-helm-charts"
-      helm-branch: "prd"
+      helm-branch: "prd-green"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_stage_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_stage_gnoscan_tx_indexer-v2.yml
@@ -1,0 +1,19 @@
+name: prd stage gnoscan push onbloc-tx-indexer v2
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  prd_stage_gnoscan_tx_indexer:
+    name: Run tx-indexer app
+    uses: ./.github/workflows/app_template.yml
+    with:
+      app-name: "tx-indexer"
+      env: "prd-stage-gnoscan-v2"
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      REGION: ${{ secrets.PRD_REGION_V2 }}

--- a/.github/workflows/prd_stage_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_stage_gnoscan_tx_indexer-v2.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "prd-stage-gnoscan-v2"
+      helm-chart-repo: "onbloc/onbloc-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_stage_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_stage_gnoscan_tx_indexer-v2.yml
@@ -13,7 +13,9 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "prd-stage-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      helm-chart-repo: "onbloc/onbloc-helm-charts"
+      helm-branch: "prd"
+      network: "staging"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_testnet_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_testnet_gnoscan_tx_indexer-v2.yml
@@ -1,0 +1,19 @@
+name: prd testnet gnoscan push onbloc-tx-indexer v2
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  prd_testnet_gnoscan_tx_indexer:
+    name: Run tx-indexer app
+    uses: ./.github/workflows/app_template.yml
+    with:
+      app-name: "tx-indexer"
+      env: "prd-testnet-gnoscan-v2"
+    secrets:
+      AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      REGION: ${{ secrets.PRD_REGION_V2 }}

--- a/.github/workflows/prd_testnet_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_testnet_gnoscan_tx_indexer-v2.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "prd-testnet-gnoscan-v2"
+      helm-chart-repo: "onbloc/onbloc-helm-chart"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/prd_testnet_gnoscan_tx_indexer-v2.yml
+++ b/.github/workflows/prd_testnet_gnoscan_tx_indexer-v2.yml
@@ -13,7 +13,9 @@ jobs:
     with:
       app-name: "tx-indexer"
       env: "prd-testnet-gnoscan-v2"
-      helm-chart-repo: "onbloc/onbloc-helm-chart"
+      helm-chart-repo: "onbloc/onbloc-helm-charts"
+      helm-branch: "prd"
+      network: "testnet"
     secrets:
       AWS_IAM_OIDC: ${{ secrets.AWS_IAM_OIDC }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.25.9
           cache: true
 
       - uses: sigstore/cosign-installer@v4.0.0
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Build
 #===============
 
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -61,6 +61,7 @@ type startCfg struct {
 	disableIntrospection bool
 	clearOnReset         bool
 	txAudit              bool
+	txAuditReset         bool
 }
 
 // newStartCmd creates the indexer start command
@@ -195,6 +196,13 @@ func (c *startCfg) registerFlags(fs *flag.FlagSet) {
 		fetch.DefaultTxAuditNap,
 		"pause between tx-audit windows; larger values lower the audit's CPU share",
 	)
+
+	fs.BoolVar(
+		&c.txAuditReset,
+		"tx-audit-reset",
+		false,
+		"ignore the stored tx-audit watermark and re-scan from audit-from-height",
+	)
 }
 
 // exec executes the indexer start command
@@ -252,6 +260,7 @@ func (c *startCfg) exec(ctx context.Context) error {
 		fetch.WithTxAudit(c.txAudit),
 		fetch.WithAuditFromHeight(c.auditFromHeight),
 		fetch.WithTxAuditThrottle(c.txAuditWindow, c.txAuditNap),
+		fetch.WithTxAuditReset(c.txAuditReset),
 	)
 
 	// The supply handler serves both the JSON-RPC and GraphQL surfaces from

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -56,6 +56,7 @@ type startCfg struct {
 	rateLimit            int
 	disableIntrospection bool
 	clearOnReset         bool
+	genesisURL           string
 }
 
 // newStartCmd creates the indexer start command
@@ -154,6 +155,13 @@ func (c *startCfg) registerFlags(fs *flag.FlagSet) {
 		"clear-on-reset",
 		false,
 		"clear all data from storage when the application resets",
+	)
+
+	fs.StringVar(
+		&c.genesisURL,
+		"genesis-url",
+		"",
+		"the URL to download genesis.json as fallback when RPC genesis call fails (for large genesis files)",
 	)
 }
 
@@ -289,6 +297,7 @@ func (c *startCfg) exec(ctx context.Context) error {
 			genesis.WithLogger(
 				logger.Named("genesis"),
 			),
+			genesis.WithURL(c.genesisURL),
 		); err != nil {
 			if errors.Is(err, context.Canceled) {
 				// Shut down while still retrying, like the other services

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -54,9 +54,13 @@ type startCfg struct {
 	maxSlots             int
 	maxChunkSize         int64
 	rateLimit            int
+	genesisURL           string
+	auditFromHeight      uint64
+	txAuditWindow        int
+	txAuditNap           time.Duration
 	disableIntrospection bool
 	clearOnReset         bool
-	genesisURL           string
+	txAudit              bool
 }
 
 // newStartCmd creates the indexer start command
@@ -163,6 +167,34 @@ func (c *startCfg) registerFlags(fs *flag.FlagSet) {
 		"",
 		"the URL to download genesis.json as fallback when RPC genesis call fails (for large genesis files)",
 	)
+
+	fs.BoolVar(
+		&c.txAudit,
+		"tx-audit",
+		false,
+		"on startup, scan stored blocks for missing transactions and backfill them (expensive; decodes every block in range)",
+	)
+
+	fs.Uint64Var(
+		&c.auditFromHeight,
+		"audit-from-height",
+		0,
+		"limit startup audits to heights >= this value (0 audits from genesis)",
+	)
+
+	fs.IntVar(
+		&c.txAuditWindow,
+		"tx-audit-window",
+		fetch.DefaultTxAuditWindow,
+		"heights processed per tx-audit window before pausing (throttle + resume granularity)",
+	)
+
+	fs.DurationVar(
+		&c.txAuditNap,
+		"tx-audit-nap",
+		fetch.DefaultTxAuditNap,
+		"pause between tx-audit windows; larger values lower the audit's CPU share",
+	)
 }
 
 // exec executes the indexer start command
@@ -215,6 +247,11 @@ func (c *startCfg) exec(ctx context.Context) error {
 		fetch.WithMaxChunkSize(c.maxChunkSize),
 		fetch.WithClearOnReset(c.clearOnReset),
 		fetch.WithDBPath(c.dbPath),
+		fetch.WithBackfillInterval(fetch.DefaultBackfillInterval),
+		fetch.WithStartupAudit(true),
+		fetch.WithTxAudit(c.txAudit),
+		fetch.WithAuditFromHeight(c.auditFromHeight),
+		fetch.WithTxAuditThrottle(c.txAuditWindow, c.txAuditNap),
 	)
 
 	// The supply handler serves both the JSON-RPC and GraphQL surfaces from

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -55,6 +55,7 @@ type startCfg struct {
 	maxChunkSize         int64
 	rateLimit            int
 	disableIntrospection bool
+	clearOnReset         bool
 }
 
 // newStartCmd creates the indexer start command
@@ -147,6 +148,13 @@ func (c *startCfg) registerFlags(fs *flag.FlagSet) {
 		defaultSupplyDenoms,
 		"comma-separated denominations whose supply (total/spendable/locked) is tracked and served by getSupply",
 	)
+
+	fs.BoolVar(
+		&c.clearOnReset,
+		"clear-on-reset",
+		false,
+		"clear all data from storage when the application resets",
+	)
 }
 
 // exec executes the indexer start command
@@ -197,6 +205,8 @@ func (c *startCfg) exec(ctx context.Context) error {
 		),
 		fetch.WithMaxSlots(c.maxSlots),
 		fetch.WithMaxChunkSize(c.maxChunkSize),
+		fetch.WithClearOnReset(c.clearOnReset),
+		fetch.WithDBPath(c.dbPath),
 	)
 
 	// The supply handler serves both the JSON-RPC and GraphQL surfaces from

--- a/fetch/backfill.go
+++ b/fetch/backfill.go
@@ -511,7 +511,7 @@ func (f *Fetcher) backfillBlock(ctx context.Context, height uint64) error {
 
 	wb := f.storage.WriteBatch()
 
-	if failed := f.persistChunk(wb, c); len(failed) > 0 {
+	if failed := f.persistChunk(wb, c, false); len(failed) > 0 {
 		if rErr := wb.Rollback(); rErr != nil {
 			return fmt.Errorf("block %d failed to save, and rollback failed: %w", height, rErr)
 		}

--- a/fetch/backfill.go
+++ b/fetch/backfill.go
@@ -259,9 +259,13 @@ func (f *Fetcher) auditTxGaps(ctx context.Context) error {
 		window = DefaultTxAuditWindow
 	}
 
+	// Resume from the persisted watermark unless a reset was requested,
+	// in which case re-scan from auditFromHeight.
 	start := f.auditFromHeight
-	if resume := f.txAuditResumeHeight(); resume > start {
-		start = resume
+	if !f.txAuditReset {
+		if resume := f.txAuditResumeHeight(); resume > start {
+			start = resume
+		}
 	}
 
 	var (

--- a/fetch/backfill.go
+++ b/fetch/backfill.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sort"
 	"sync"
 	"time"
@@ -338,7 +337,7 @@ func (f *Fetcher) auditTxWindow(ctx context.Context, from, to uint64, queued *in
 	}
 	defer blockIt.Close()
 
-	txIt, err := f.storage.TxIterator(from, to, 0, math.MaxUint32)
+	txIt, err := f.storage.TxIterator(from, to, 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open tx iterator for tx audit: %w", err)
 	}

--- a/fetch/backfill.go
+++ b/fetch/backfill.go
@@ -1,0 +1,523 @@
+package fetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	bft_types "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"go.uber.org/zap"
+
+	"github.com/gnolang/tx-indexer/storage"
+	storageErrors "github.com/gnolang/tx-indexer/storage/errors"
+)
+
+// blockHeightScanner is an optional storage capability: iterate stored block
+// heights straight from the keys, without decoding block values.
+type blockHeightScanner interface {
+	BlockHeightIterator(fromBlockNum, toBlockNum uint64) (storage.Iterator[uint64], error)
+}
+
+// blockHeights iterates stored block heights in [from, to], preferring the
+// cheap key-only scan and falling back to decoding blocks when unavailable.
+func (f *Fetcher) blockHeights(from, to uint64) (storage.Iterator[uint64], error) {
+	if s, ok := f.storage.(blockHeightScanner); ok {
+		return s.BlockHeightIterator(from, to)
+	}
+
+	it, err := f.storage.BlockIterator(from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	return &decodingHeightIter{it: it}, nil
+}
+
+// decodingHeightIter is the blockHeights fallback: it reads heights by decoding
+// each block from an ordinary BlockIterator.
+type decodingHeightIter struct {
+	it storage.Iterator[*bft_types.Block]
+}
+
+func (d *decodingHeightIter) Next() bool { return d.it.Next() }
+
+func (d *decodingHeightIter) Value() (uint64, error) {
+	block, err := d.it.Value()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(block.Height), nil
+}
+
+func (d *decodingHeightIter) Error() error { return d.it.Error() }
+func (d *decodingHeightIter) Close() error { return d.it.Close() }
+
+// maxAuditGaps caps how many missing heights an audit enqueues in one pass, so
+// a badly corrupted or near-empty store can't blow up memory. The rest is
+// picked up on a later run.
+const maxAuditGaps = 100_000
+
+// gapTracker is a thread-safe, de-duplicated set of block heights pending
+// backfill (because they failed to fetch or to save).
+type gapTracker struct {
+	set map[uint64]struct{}
+	mu  sync.Mutex
+}
+
+func newGapTracker() *gapTracker {
+	return &gapTracker{
+		set: make(map[uint64]struct{}),
+	}
+}
+
+func (g *gapTracker) add(heights ...uint64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for _, h := range heights {
+		g.set[h] = struct{}{}
+	}
+}
+
+func (g *gapTracker) remove(height uint64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	delete(g.set, height)
+}
+
+// snapshot returns the queued heights, sorted ascending.
+func (g *gapTracker) snapshot() []uint64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	heights := make([]uint64, 0, len(g.set))
+	for h := range g.set {
+		heights = append(heights, h)
+	}
+
+	sort.Slice(heights, func(i, j int) bool {
+		return heights[i] < heights[j]
+	})
+
+	return heights
+}
+
+// len returns the number of queued heights.
+func (g *gapTracker) len() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	return len(g.set)
+}
+
+// runBackfiller is the background loop that repairs gaps in the indexed data:
+// an optional one-time storage audit on startup, then periodic draining of the
+// queued heights (re-fetching only the missing blocks).
+func (f *Fetcher) runBackfiller(ctx context.Context) {
+	if f.auditOnStart {
+		if err := f.auditGaps(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			f.logger.Error("gap audit failed", zap.Error(err))
+		}
+	}
+
+	if f.txAudit {
+		if err := f.auditTxGaps(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			f.logger.Error("tx gap audit failed", zap.Error(err))
+		}
+	}
+
+	// Drain anything the audit (or the fetch loop) has already queued
+	f.drainGaps(ctx)
+
+	ticker := time.NewTicker(f.backfillInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			f.logger.Info("Backfiller service shut down")
+
+			return
+		case <-ticker.C:
+			f.drainGaps(ctx)
+		}
+	}
+}
+
+// auditGaps queues every missing height between genesis and the latest saved
+// height, recovering gaps that predate this process (e.g. blocks dropped by an
+// older, buggy build).
+func (f *Fetcher) auditGaps(ctx context.Context) error {
+	latest, err := f.storage.GetLatestHeight()
+	if err != nil {
+		if errors.Is(err, storageErrors.ErrNotFound) {
+			// Nothing indexed yet, nothing to audit
+			return nil
+		}
+
+		return fmt.Errorf("unable to read latest height for audit: %w", err)
+	}
+
+	it, err := f.blockHeights(f.auditFromHeight, latest)
+	if err != nil {
+		return fmt.Errorf("unable to open block height iterator for audit: %w", err)
+	}
+	defer it.Close()
+
+	var (
+		expected = f.auditFromHeight // next height we expect to see
+		queued   int
+	)
+
+	for it.Next() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		height, err := it.Value()
+		if err != nil {
+			return fmt.Errorf("unable to read block height during audit: %w", err)
+		}
+
+		// Any heights between what we expected and this block are missing
+		for h := expected; h < height && queued < maxAuditGaps; h++ {
+			f.gaps.add(h)
+
+			queued++
+		}
+
+		expected = height + 1
+	}
+
+	if err := it.Error(); err != nil {
+		return fmt.Errorf("block height iterator error during audit: %w", err)
+	}
+
+	// Any heights between the last stored block and the latest height are missing
+	for h := expected; h <= latest && queued < maxAuditGaps; h++ {
+		f.gaps.add(h)
+
+		queued++
+	}
+
+	if queued > 0 {
+		f.logger.Warn(
+			"gap audit found missing blocks, queued for backfill",
+			zap.Int("count", queued),
+			zap.Uint64("latest", latest),
+		)
+
+		if queued >= maxAuditGaps {
+			f.logger.Warn(
+				"gap audit hit the enqueue cap; remaining gaps will be picked up on a later run",
+				zap.Int("cap", maxAuditGaps),
+			)
+		}
+	}
+
+	return nil
+}
+
+// txAuditWatermark is an optional storage capability: persist how far the
+// tx-completeness audit has verified so it can resume across restarts instead
+// of re-scanning from the start.
+type txAuditWatermark interface {
+	GetTxAuditHeight() (uint64, error)
+	SetTxAuditHeight(uint64) error
+}
+
+// auditTxGaps queues every height whose stored transaction count is below the
+// block's declared NumTxs, recovering blocks saved without (some of) their txs.
+//
+// It is scoped to [auditFromHeight, latest] and processed in windows: each
+// window is audited with its own short-lived iterators (so the DB snapshot is
+// released between windows) and is followed by a nap, which caps the audit's
+// CPU share on constrained deployments. Progress is persisted per fully-audited
+// window (see txAuditWatermark), so a restart resumes instead of re-scanning —
+// and once the whole range is complete, later runs do almost nothing.
+//
+// Decoding every block to read NumTxs makes this far more expensive than
+// auditGaps, hence opt-in.
+func (f *Fetcher) auditTxGaps(ctx context.Context) error {
+	latest, err := f.storage.GetLatestHeight()
+	if err != nil {
+		if errors.Is(err, storageErrors.ErrNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("unable to read latest height for tx audit: %w", err)
+	}
+
+	window := uint64(f.txAuditWindow)
+	if window == 0 {
+		window = DefaultTxAuditWindow
+	}
+
+	start := f.auditFromHeight
+	if resume := f.txAuditResumeHeight(); resume > start {
+		start = resume
+	}
+
+	var (
+		queued  int
+		blocked bool // once an incomplete height is found, stop advancing the watermark
+	)
+
+	for cur := start; cur <= latest; cur += window {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		end := cur + window - 1
+		if end > latest || end < cur { // clamp, and guard the cur+window overflow
+			end = latest
+		}
+
+		firstIncomplete, err := f.auditTxWindow(ctx, cur, end, &queued)
+		if err != nil {
+			return err
+		}
+
+		// Advance the durable watermark only while every audited height so far
+		// is complete; freeze it just below the first incomplete height so a
+		// restart re-checks it (and it advances again once backfill fills it).
+		if !blocked {
+			if firstIncomplete != nil {
+				blocked = true
+
+				if *firstIncomplete > 0 {
+					f.persistTxAuditHeight(*firstIncomplete - 1)
+				}
+			} else {
+				f.persistTxAuditHeight(end)
+			}
+		}
+
+		if end == latest || queued >= maxAuditGaps {
+			break // done (also avoids cur+window wrapping past the end)
+		}
+
+		// Throttle: pause between windows so the audit does not monopolise the CPU
+		if f.txAuditNap > 0 {
+			if err := sleepWithContext(ctx, f.txAuditNap); err != nil {
+				return err
+			}
+		}
+	}
+
+	if queued > 0 {
+		f.logger.Warn(
+			"tx audit found blocks with missing transactions, queued for backfill",
+			zap.Int("count", queued),
+			zap.Uint64("from", start),
+			zap.Uint64("latest", latest),
+		)
+	}
+
+	return nil
+}
+
+// auditTxWindow audits the tx-completeness of blocks in [from, to], queueing
+// any incomplete height, and returns the lowest incomplete height it found (or
+// nil). It walks the block and transaction iterators together in a single
+// height-ordered pass.
+func (f *Fetcher) auditTxWindow(ctx context.Context, from, to uint64, queued *int) (*uint64, error) {
+	blockIt, err := f.storage.BlockIterator(from, to)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open block iterator for tx audit: %w", err)
+	}
+	defer blockIt.Close()
+
+	txIt, err := f.storage.TxIterator(from, to, 0, math.MaxUint32)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open tx iterator for tx audit: %w", err)
+	}
+	defer txIt.Close()
+
+	// Prime the tx iterator with its first transaction (if any)
+	txHeight, txValid, err := nextTxHeight(txIt)
+	if err != nil {
+		return nil, err
+	}
+
+	var firstIncomplete *uint64
+
+	for blockIt.Next() {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		block, err := blockIt.Value()
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode block during tx audit: %w", err)
+		}
+
+		if block.NumTxs == 0 {
+			continue
+		}
+
+		height := uint64(block.Height)
+
+		// Skip any stray transactions that sit below this block's height
+		for txValid && txHeight < height {
+			if txHeight, txValid, err = nextTxHeight(txIt); err != nil {
+				return nil, err
+			}
+		}
+
+		// Count the transactions stored for this height
+		var stored int64
+		for txValid && txHeight == height {
+			stored++
+
+			if txHeight, txValid, err = nextTxHeight(txIt); err != nil {
+				return nil, err
+			}
+		}
+
+		if stored < block.NumTxs {
+			if *queued < maxAuditGaps {
+				f.gaps.add(height)
+
+				*queued++
+			}
+
+			if firstIncomplete == nil {
+				h := height
+				firstIncomplete = &h
+			}
+		}
+	}
+
+	if err := blockIt.Error(); err != nil {
+		return nil, fmt.Errorf("block iterator error during tx audit: %w", err)
+	}
+
+	if err := txIt.Error(); err != nil {
+		return nil, fmt.Errorf("tx iterator error during tx audit: %w", err)
+	}
+
+	return firstIncomplete, nil
+}
+
+// txAuditResumeHeight returns the height the tx audit should resume from (the
+// persisted watermark + 1), or 0 when there is no watermark / no support.
+func (f *Fetcher) txAuditResumeHeight() uint64 {
+	wm, ok := f.storage.(txAuditWatermark)
+	if !ok {
+		return 0
+	}
+
+	height, err := wm.GetTxAuditHeight()
+	if err != nil {
+		return 0 // not set yet, or a read error: start from the configured floor
+	}
+
+	return height + 1
+}
+
+// persistTxAuditHeight records how far the tx audit has verified, if the
+// storage supports it.
+func (f *Fetcher) persistTxAuditHeight(height uint64) {
+	wm, ok := f.storage.(txAuditWatermark)
+	if !ok {
+		return
+	}
+
+	if err := wm.SetTxAuditHeight(height); err != nil {
+		f.logger.Warn("unable to persist tx audit height", zap.Uint64("height", height), zap.Error(err))
+	}
+}
+
+// nextTxHeight advances the transaction iterator and returns the height of the
+// next transaction, whether one exists, and any error encountered.
+func nextTxHeight(txIt storage.Iterator[*bft_types.TxResult]) (uint64, bool, error) {
+	if !txIt.Next() {
+		return 0, false, nil
+	}
+
+	tx, err := txIt.Value()
+	if err != nil {
+		return 0, false, fmt.Errorf("unable to decode tx during tx audit: %w", err)
+	}
+
+	return uint64(tx.Height), true, nil
+}
+
+// drainGaps attempts to backfill every currently queued height. Heights that
+// are successfully fetched and saved are removed from the queue; the rest stay
+// queued for the next backfiller tick.
+func (f *Fetcher) drainGaps(ctx context.Context) {
+	heights := f.gaps.snapshot()
+	if len(heights) == 0 {
+		return
+	}
+
+	f.logger.Info("Backfilling missing blocks", zap.Int("count", len(heights)))
+
+	var repaired int
+
+	for _, height := range heights {
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err := f.backfillBlock(ctx, height); err != nil {
+			f.logger.Warn(
+				"unable to backfill block, will retry",
+				zap.Uint64("height", height),
+				zap.Error(err),
+			)
+
+			continue
+		}
+
+		f.gaps.remove(height)
+
+		repaired++
+	}
+
+	if repaired > 0 {
+		f.logger.Info(
+			"Backfilled missing blocks",
+			zap.Int("repaired", repaired),
+			zap.Int("remaining", f.gaps.len()),
+		)
+	}
+}
+
+// backfillBlock fetches a single height (reusing the retrying fetch path) and
+// persists it without touching the latest-height pointer, so filling an old
+// gap never regresses the fetcher's forward progress.
+func (f *Fetcher) backfillBlock(ctx context.Context, height uint64) error {
+	c, missing, err := fetchChunk(ctx, f.client, chunkRange{from: height, to: height}, f.retry, f.logger)
+	if err != nil {
+		return err
+	}
+
+	if len(missing) > 0 || len(c.blocks) == 0 {
+		return fmt.Errorf("block %d still unavailable", height)
+	}
+
+	wb := f.storage.WriteBatch()
+
+	if failed := f.persistChunk(wb, c); len(failed) > 0 {
+		if rErr := wb.Rollback(); rErr != nil {
+			return fmt.Errorf("block %d failed to save, and rollback failed: %w", height, rErr)
+		}
+
+		return fmt.Errorf("block %d failed to save", height)
+	}
+
+	if err := wb.Commit(); err != nil {
+		return fmt.Errorf("unable to commit backfilled block %d: %w", height, err)
+	}
+
+	return nil
+}

--- a/fetch/backfill_test.go
+++ b/fetch/backfill_test.go
@@ -321,6 +321,37 @@ func TestAuditTxGaps_ResumesFromWatermark(t *testing.T) {
 	assert.Equal(t, []uint64{3}, f.gaps.snapshot(), "heights at or below the watermark must be skipped")
 }
 
+func TestAuditTxGaps_ResetIgnoresWatermark(t *testing.T) {
+	t.Parallel()
+
+	// All incomplete, watermark says <= 2 verified, but a reset is requested
+	// with a floor of height 2 -> heights 2 and 3 are re-scanned (1 is below
+	// the floor), ignoring the watermark.
+	blocks := txAuditBlocks(1, 2, 3)
+
+	storageMock := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) { return 3, nil },
+		BlockIteratorFn: func(from, to uint64) (storage.Iterator[*types.Block], error) {
+			return mock.NewSliceBlockIterator(blocksInRange(blocks, from, to)), nil
+		},
+		TxIteratorFn: func(_, _ uint64, _, _ uint32) (storage.Iterator[*types.TxResult], error) {
+			return mock.NewSliceTxIterator(nil), nil
+		},
+		GetTxAuditHeightFn: func() (uint64, error) { return 2, nil },
+	}
+
+	f := New(
+		storageMock,
+		&mockClient{},
+		&mockEvents{},
+		WithAuditFromHeight(2),
+		WithTxAuditReset(true),
+	)
+
+	require.NoError(t, f.auditTxGaps(context.Background()))
+	assert.Equal(t, []uint64{2, 3}, f.gaps.snapshot(), "reset must re-scan from the floor, ignoring the watermark")
+}
+
 func TestAuditTxGaps_PersistsWatermarkPerWindow(t *testing.T) {
 	t.Parallel()
 

--- a/fetch/backfill_test.go
+++ b/fetch/backfill_test.go
@@ -1,0 +1,625 @@
+package fetch
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clientTypes "github.com/gnolang/tx-indexer/client/types"
+	"github.com/gnolang/tx-indexer/internal/mock"
+	"github.com/gnolang/tx-indexer/storage"
+	storageErrors "github.com/gnolang/tx-indexer/storage/errors"
+)
+
+// fastRetry is a retry policy with a negligible delay, for tests.
+var fastRetry = retryConfig{
+	maxRetries: 5,
+	retryDelay: time.Millisecond,
+}
+
+// erroringBatch returns a batch whose Execute always fails, forcing the
+// sequential fetch fallback (which is the path that exercises retries).
+func erroringBatch() clientTypes.Batch {
+	return &mockBatch{
+		executeFn: func(_ context.Context) ([]any, error) {
+			return nil, errors.New("batch unavailable")
+		},
+		countFn: func() int { return 1 },
+	}
+}
+
+// blocksAtHeights builds empty blocks at the given heights.
+func blocksAtHeights(heights ...int64) []*types.Block {
+	blocks := make([]*types.Block, len(heights))
+	for i, h := range heights {
+		blocks[i] = &types.Block{Header: types.Header{Height: h}}
+	}
+
+	return blocks
+}
+
+func TestGapTracker(t *testing.T) {
+	t.Parallel()
+
+	g := newGapTracker()
+	require.Equal(t, 0, g.len())
+
+	g.add(3, 1, 2, 1) // duplicate 1 collapses
+	require.Equal(t, 3, g.len())
+	assert.Equal(t, []uint64{1, 2, 3}, g.snapshot())
+
+	g.remove(2)
+	assert.Equal(t, []uint64{1, 3}, g.snapshot())
+}
+
+func TestAuditGaps(t *testing.T) {
+	t.Parallel()
+
+	testTable := []struct {
+		name         string
+		stored       []int64
+		latestErr    error
+		expectedGaps []uint64
+		latest       uint64
+	}{
+		{"nothing indexed yet", nil, storageErrors.ErrNotFound, []uint64{}, 0},
+		{"no gaps", []int64{0, 1, 2, 3}, nil, []uint64{}, 3},
+		{"leading gap", []int64{2, 3}, nil, []uint64{0, 1}, 3},
+		{"middle gaps", []int64{0, 1, 3, 5}, nil, []uint64{2, 4}, 5},
+		{"trailing gap", []int64{0, 1, 2}, nil, []uint64{3, 4, 5}, 5},
+		{"only genesis stored", []int64{0}, nil, []uint64{1, 2, 3}, 3},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			storageMock := &mock.Storage{
+				GetLatestSavedHeightFn: func() (uint64, error) {
+					return testCase.latest, testCase.latestErr
+				},
+				BlockIteratorFn: func(_, _ uint64) (storage.Iterator[*types.Block], error) {
+					return mock.NewSliceBlockIterator(blocksAtHeights(testCase.stored...)), nil
+				},
+			}
+
+			f := New(storageMock, &mockClient{}, &mockEvents{})
+
+			require.NoError(t, f.auditGaps(context.Background()))
+			assert.Equal(t, testCase.expectedGaps, f.gaps.snapshot())
+		})
+	}
+}
+
+// heightScannerStorage is a storage that also implements blockHeightScanner,
+// used to verify auditGaps prefers the cheap key-only scan.
+type heightScannerStorage struct {
+	*mock.Storage
+
+	heightIter func(uint64, uint64) (storage.Iterator[uint64], error)
+}
+
+func (h *heightScannerStorage) BlockHeightIterator(from, to uint64) (storage.Iterator[uint64], error) {
+	return h.heightIter(from, to)
+}
+
+// uint64SliceIter is an in-memory Iterator[uint64] for tests.
+type uint64SliceIter struct {
+	vals  []uint64
+	index int
+}
+
+func newUint64SliceIter(vals []uint64) *uint64SliceIter {
+	return &uint64SliceIter{vals: vals, index: -1}
+}
+
+func (it *uint64SliceIter) Next() bool {
+	it.index++
+
+	return it.index < len(it.vals)
+}
+
+func (it *uint64SliceIter) Value() (uint64, error) { return it.vals[it.index], nil }
+func (it *uint64SliceIter) Error() error           { return nil }
+func (it *uint64SliceIter) Close() error           { return nil }
+
+func TestAuditGaps_PrefersCheapHeightScan(t *testing.T) {
+	t.Parallel()
+
+	storageMock := &heightScannerStorage{
+		Storage: &mock.Storage{
+			GetLatestSavedHeightFn: func() (uint64, error) { return 3, nil },
+			BlockIteratorFn: func(_, _ uint64) (storage.Iterator[*types.Block], error) {
+				t.Fatal("BlockIterator must not be used when the cheap scan is available")
+
+				return nil, nil
+			},
+		},
+		heightIter: func(_, _ uint64) (storage.Iterator[uint64], error) {
+			return newUint64SliceIter([]uint64{0, 2}), nil // missing 1 and 3
+		},
+	}
+
+	f := New(storageMock, &mockClient{}, &mockEvents{})
+
+	require.NoError(t, f.auditGaps(context.Background()))
+	assert.Equal(t, []uint64{1, 3}, f.gaps.snapshot())
+}
+
+func TestAuditTxGaps(t *testing.T) {
+	t.Parallel()
+
+	type blockSpec struct {
+		height int64
+		numTxs int64
+	}
+
+	testTable := []struct {
+		name         string
+		blocks       []blockSpec
+		txHeights    []int64 // one entry per stored tx, ascending
+		latestErr    error
+		expectedGaps []uint64
+		latest       uint64
+	}{
+		{"nothing indexed yet", nil, nil, storageErrors.ErrNotFound, []uint64{}, 0},
+		{
+			"all complete",
+			[]blockSpec{{1, 2}, {2, 1}},
+			[]int64{1, 1, 2},
+			nil,
+			[]uint64{},
+			2,
+		},
+		{
+			"partial and fully missing",
+			[]blockSpec{{1, 2}, {2, 2}, {3, 2}},
+			[]int64{1, 1, 2},
+			nil,
+			[]uint64{2, 3},
+			3,
+		},
+		{
+			"empty blocks are skipped",
+			[]blockSpec{{1, 0}, {2, 0}},
+			nil,
+			nil,
+			[]uint64{},
+			2,
+		},
+		{
+			"trailing block incomplete",
+			[]blockSpec{{1, 1}, {2, 2}},
+			[]int64{1, 2},
+			nil,
+			[]uint64{2},
+			2,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			blocks := make([]*types.Block, len(testCase.blocks))
+			for i, spec := range testCase.blocks {
+				blocks[i] = &types.Block{
+					Header: types.Header{Height: spec.height, NumTxs: spec.numTxs},
+				}
+			}
+
+			txs := make([]*types.TxResult, len(testCase.txHeights))
+			for i, h := range testCase.txHeights {
+				txs[i] = &types.TxResult{Height: h}
+			}
+
+			storageMock := &mock.Storage{
+				GetLatestSavedHeightFn: func() (uint64, error) {
+					return testCase.latest, testCase.latestErr
+				},
+				BlockIteratorFn: func(_, _ uint64) (storage.Iterator[*types.Block], error) {
+					return mock.NewSliceBlockIterator(blocks), nil
+				},
+				TxIteratorFn: func(_, _ uint64, _, _ uint32) (storage.Iterator[*types.TxResult], error) {
+					return mock.NewSliceTxIterator(txs), nil
+				},
+			}
+
+			f := New(storageMock, &mockClient{}, &mockEvents{})
+
+			require.NoError(t, f.auditTxGaps(context.Background()))
+			assert.Equal(t, testCase.expectedGaps, f.gaps.snapshot())
+		})
+	}
+}
+
+// blocksInRange / txsInRange let the mock iterators honor the window bounds the
+// windowed tx audit passes in.
+func blocksInRange(blocks []*types.Block, from, to uint64) []*types.Block {
+	out := make([]*types.Block, 0, len(blocks))
+	for _, b := range blocks {
+		if uint64(b.Height) >= from && uint64(b.Height) <= to {
+			out = append(out, b)
+		}
+	}
+
+	return out
+}
+
+func txsInRange(txs []*types.TxResult, from, to uint64) []*types.TxResult {
+	out := make([]*types.TxResult, 0, len(txs))
+	for _, tx := range txs {
+		if uint64(tx.Height) >= from && uint64(tx.Height) <= to {
+			out = append(out, tx)
+		}
+	}
+
+	return out
+}
+
+// txAuditBlocks builds single-tx blocks at the given heights.
+func txAuditBlocks(heights ...int64) []*types.Block {
+	blocks := make([]*types.Block, len(heights))
+	for i, h := range heights {
+		blocks[i] = &types.Block{Header: types.Header{Height: h, NumTxs: 1}}
+	}
+
+	return blocks
+}
+
+func TestAuditTxGaps_HonorsFromHeight(t *testing.T) {
+	t.Parallel()
+
+	// Heights 1 and 3 declare a tx but none are stored (both incomplete).
+	blocks := txAuditBlocks(1, 3)
+
+	storageMock := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) { return 3, nil },
+		BlockIteratorFn: func(from, to uint64) (storage.Iterator[*types.Block], error) {
+			return mock.NewSliceBlockIterator(blocksInRange(blocks, from, to)), nil
+		},
+		TxIteratorFn: func(_, _ uint64, _, _ uint32) (storage.Iterator[*types.TxResult], error) {
+			return mock.NewSliceTxIterator(nil), nil
+		},
+	}
+
+	// Floor at height 2: height 1 must be skipped, only 3 is queued.
+	f := New(storageMock, &mockClient{}, &mockEvents{}, WithAuditFromHeight(2))
+
+	require.NoError(t, f.auditTxGaps(context.Background()))
+	assert.Equal(t, []uint64{3}, f.gaps.snapshot())
+}
+
+func TestAuditTxGaps_ResumesFromWatermark(t *testing.T) {
+	t.Parallel()
+
+	// All incomplete, but the watermark says heights <= 2 are already verified.
+	blocks := txAuditBlocks(1, 2, 3)
+	watermark := uint64(2)
+
+	storageMock := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) { return 3, nil },
+		BlockIteratorFn: func(from, to uint64) (storage.Iterator[*types.Block], error) {
+			return mock.NewSliceBlockIterator(blocksInRange(blocks, from, to)), nil
+		},
+		TxIteratorFn: func(_, _ uint64, _, _ uint32) (storage.Iterator[*types.TxResult], error) {
+			return mock.NewSliceTxIterator(nil), nil
+		},
+		GetTxAuditHeightFn: func() (uint64, error) { return watermark, nil },
+	}
+
+	f := New(storageMock, &mockClient{}, &mockEvents{})
+
+	require.NoError(t, f.auditTxGaps(context.Background()))
+	assert.Equal(t, []uint64{3}, f.gaps.snapshot(), "heights at or below the watermark must be skipped")
+}
+
+func TestAuditTxGaps_PersistsWatermarkPerWindow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("advances to latest when everything is complete", func(t *testing.T) {
+		t.Parallel()
+
+		blocks := txAuditBlocks(1, 2, 3, 4)
+		txs := []*types.TxResult{{Height: 1}, {Height: 2}, {Height: 3}, {Height: 4}}
+
+		var persisted []uint64
+
+		storageMock := &mock.Storage{
+			GetLatestSavedHeightFn: func() (uint64, error) { return 4, nil },
+			BlockIteratorFn: func(from, to uint64) (storage.Iterator[*types.Block], error) {
+				return mock.NewSliceBlockIterator(blocksInRange(blocks, from, to)), nil
+			},
+			TxIteratorFn: func(from, to uint64, _, _ uint32) (storage.Iterator[*types.TxResult], error) {
+				return mock.NewSliceTxIterator(txsInRange(txs, from, to)), nil
+			},
+			SetTxAuditHeightFn: func(h uint64) error {
+				persisted = append(persisted, h)
+
+				return nil
+			},
+		}
+
+		// from height 1, window of 2 -> [1,2] then [3,4]
+		f := New(storageMock, &mockClient{}, &mockEvents{}, WithAuditFromHeight(1), WithTxAuditThrottle(2, 0))
+
+		require.NoError(t, f.auditTxGaps(context.Background()))
+		assert.Empty(t, f.gaps.snapshot())
+		assert.Equal(t, []uint64{2, 4}, persisted, "watermark advances per completed window")
+	})
+
+	t.Run("freezes just below the first incomplete height", func(t *testing.T) {
+		t.Parallel()
+
+		// Height 3 is incomplete; 1, 2, 4 are complete.
+		blocks := txAuditBlocks(1, 2, 3, 4)
+		txs := []*types.TxResult{{Height: 1}, {Height: 2}, {Height: 4}}
+
+		var persisted []uint64
+
+		storageMock := &mock.Storage{
+			GetLatestSavedHeightFn: func() (uint64, error) { return 4, nil },
+			BlockIteratorFn: func(from, to uint64) (storage.Iterator[*types.Block], error) {
+				return mock.NewSliceBlockIterator(blocksInRange(blocks, from, to)), nil
+			},
+			TxIteratorFn: func(from, to uint64, _, _ uint32) (storage.Iterator[*types.TxResult], error) {
+				return mock.NewSliceTxIterator(txsInRange(txs, from, to)), nil
+			},
+			SetTxAuditHeightFn: func(h uint64) error {
+				persisted = append(persisted, h)
+
+				return nil
+			},
+		}
+
+		// from height 1, window of 1 -> [1],[2],[3],[4]
+		f := New(storageMock, &mockClient{}, &mockEvents{}, WithAuditFromHeight(1), WithTxAuditThrottle(1, 0))
+
+		require.NoError(t, f.auditTxGaps(context.Background()))
+		assert.Equal(t, []uint64{3}, f.gaps.snapshot())
+		// 1 and 2 complete -> persist 1, 2; then height 3 incomplete freezes at 2;
+		// nothing persisted for 3 or 4.
+		assert.Equal(t, []uint64{1, 2, 2}, persisted)
+	})
+}
+
+func TestWriteSlot_QueuesFailedHeights(t *testing.T) {
+	t.Parallel()
+
+	txs := generateTransactions(t, 2)
+	blocks := generateBlocks(t, 4, txs)
+
+	testTable := []struct {
+		name         string
+		batch        func() storage.Batch
+		expectedGaps []uint64
+	}{
+		{
+			"block save fails",
+			func() storage.Batch {
+				return &mock.WriteBatch{
+					SetBlockFn: func(*types.Block) error { return errors.New("amino incompatible") },
+				}
+			},
+			[]uint64{3},
+		},
+		{
+			"tx save fails",
+			func() storage.Batch {
+				return &mock.WriteBatch{
+					SetTxFn: func(*types.TxResult) error { return errors.New("disk full") },
+				}
+			},
+			[]uint64{3},
+		},
+		{
+			"everything saves",
+			func() storage.Batch { return &mock.WriteBatch{} },
+			[]uint64{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			storageMock := &mock.Storage{GetWriteBatchFn: testCase.batch}
+
+			f := New(storageMock, &mockClient{}, &mockEvents{})
+
+			s := &slot{
+				chunk: &chunk{
+					blocks:  []*types.Block{blocks[3]},
+					results: [][]*types.TxResult{{{Height: 3}, {Height: 3}}},
+				},
+				chunkRange: chunkRange{from: 3, to: 3},
+			}
+
+			require.NoError(t, f.writeSlot(s))
+			assert.Equal(t, testCase.expectedGaps, f.gaps.snapshot())
+		})
+	}
+}
+
+func TestDrainGaps(t *testing.T) {
+	t.Parallel()
+
+	const txCount = 3
+
+	txs := generateTransactions(t, txCount)
+	blocks := generateBlocks(t, 6, txs)
+
+	t.Run("backfills queued heights without advancing the latest height", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			mu          sync.Mutex
+			savedBlocks []*types.Block
+			latestSet   bool
+		)
+
+		storageMock := &mock.Storage{
+			GetWriteBatchFn: func() storage.Batch {
+				return &mock.WriteBatch{
+					SetBlockFn: func(b *types.Block) error {
+						mu.Lock()
+						defer mu.Unlock()
+
+						savedBlocks = append(savedBlocks, b)
+
+						return nil
+					},
+					SetLatestHeightFn: func(uint64) error {
+						latestSet = true
+
+						return nil
+					},
+				}
+			},
+		}
+
+		client := &mockClient{
+			createBatchFn: erroringBatch,
+			getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+				return &core_types.ResultBlock{Block: blocks[num]}, nil
+			},
+			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+				return mockBlockResults(int64(num), txCount), nil
+			},
+		}
+
+		f := New(storageMock, client, &mockEvents{}, WithChunkFetchRetry(2, time.Millisecond))
+		f.gaps.add(2, 4)
+
+		f.drainGaps(context.Background())
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Len(t, savedBlocks, 2)
+		assert.Equal(t, 0, f.gaps.len(), "queue should be drained")
+		assert.False(t, latestSet, "backfill must not advance the latest height")
+	})
+
+	t.Run("keeps a height queued when it still cannot be fetched", func(t *testing.T) {
+		t.Parallel()
+
+		client := &mockClient{
+			createBatchFn: erroringBatch,
+			getBlockFn: func(uint64) (*core_types.ResultBlock, error) {
+				return nil, errors.New("still down")
+			},
+		}
+
+		f := New(&mock.Storage{}, client, &mockEvents{}, WithChunkFetchRetry(1, time.Millisecond))
+		f.gaps.add(7)
+
+		f.drainGaps(context.Background())
+
+		assert.Equal(t, []uint64{7}, f.gaps.snapshot(), "unfetchable height must stay queued")
+	})
+
+	t.Run("keeps a height queued when the fetched block fails to save", func(t *testing.T) {
+		t.Parallel()
+
+		storageMock := &mock.Storage{
+			GetWriteBatchFn: func() storage.Batch {
+				return &mock.WriteBatch{
+					SetBlockFn: func(*types.Block) error { return errors.New("amino incompatible") },
+				}
+			},
+		}
+
+		client := &mockClient{
+			createBatchFn: erroringBatch,
+			getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+				return &core_types.ResultBlock{Block: blocks[num]}, nil
+			},
+			getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+				return mockBlockResults(int64(num), txCount), nil
+			},
+		}
+
+		f := New(storageMock, client, &mockEvents{}, WithChunkFetchRetry(1, time.Millisecond))
+		f.gaps.add(5)
+
+		f.drainGaps(context.Background())
+
+		assert.Equal(t, []uint64{5}, f.gaps.snapshot(), "unsavable height must stay queued")
+	})
+}
+
+func TestRunBackfiller_AuditsThenBackfills(t *testing.T) {
+	t.Parallel()
+
+	const txCount = 1
+
+	txs := generateTransactions(t, txCount)
+	blocks := generateBlocks(t, 4, txs)
+
+	// Stored: 0, 2 (missing 1), latest 2
+	stored := blocksAtHeights(0, 2)
+
+	var (
+		mu    sync.Mutex
+		saved []*types.Block
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	storageMock := &mock.Storage{
+		GetLatestSavedHeightFn: func() (uint64, error) { return 2, nil },
+		BlockIteratorFn: func(_, _ uint64) (storage.Iterator[*types.Block], error) {
+			return mock.NewSliceBlockIterator(stored), nil
+		},
+		GetWriteBatchFn: func() storage.Batch {
+			return &mock.WriteBatch{
+				SetBlockFn: func(b *types.Block) error {
+					mu.Lock()
+					defer mu.Unlock()
+
+					saved = append(saved, b)
+
+					cancel() // stop the backfiller once the gap is filled
+
+					return nil
+				},
+			}
+		},
+	}
+
+	client := &mockClient{
+		createBatchFn: erroringBatch,
+		getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+			return &core_types.ResultBlock{Block: blocks[num]}, nil
+		},
+		getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+			return mockBlockResults(int64(num), txCount), nil
+		},
+	}
+
+	f := New(
+		storageMock,
+		client,
+		&mockEvents{},
+		WithBackfillInterval(time.Hour), // ticker must not fire before ctx is cancelled
+		WithStartupAudit(true),
+		WithChunkFetchRetry(2, time.Millisecond),
+	)
+
+	f.runBackfiller(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, saved, 1)
+	assert.EqualValues(t, 1, saved[0].Height)
+}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -63,6 +63,7 @@ type Fetcher struct {
 	clearOnReset bool // wipe storage when the chain resets
 	auditOnStart bool // scan storage for missing-block gaps on startup
 	txAudit      bool // also scan for blocks with missing txs on startup (expensive)
+	txAuditReset bool // ignore the persisted tx audit watermark
 }
 
 // New creates a new data fetcher instance

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"time"
 
@@ -19,29 +20,49 @@ import (
 const (
 	DefaultMaxSlots     = 100
 	DefaultMaxChunkSize = 100
+
+	// DefaultBackfillInterval is how often the backfiller drains queued gaps
+	// (heights that failed to fetch / save) and re-fetches them.
+	DefaultBackfillInterval = 30 * time.Second
+
+	// DefaultTxAuditWindow is how many heights the tx-completeness audit
+	// processes before pausing (throttle + watermark granularity).
+	DefaultTxAuditWindow = 20_000
+
+	// DefaultTxAuditNap is the pause between tx-audit windows,
+	// which caps how much of the CPU the audit takes on constrained deployments.
+	DefaultTxAuditNap = 100 * time.Millisecond
 )
 
 // Fetcher is an instance of the block indexer
 // fetcher
 type Fetcher struct {
-	storage storage.Storage
-	client  Client
-	events  Events
-
+	storage     storage.Storage
+	client      Client
+	events      Events
 	logger      *zap.Logger
 	chunkBuffer *slots
+	gaps        *gapTracker // heights pending backfill (fetch or save failures)
+	dbPath      string
 
 	// retrying holds the chunk ranges whose fetch failed, mapped to whether
 	// the range is waiting to be respawned (true) or already back in flight
 	// (false). A range leaves the map only once it has been fetched in full
 	retrying map[chunkRange]bool
 
-	maxSlots        int
-	maxChunkSize    int64
-	latestChunkSize int
+	maxSlots         int
+	maxChunkSize     int64
+	latestChunkSize  int
+	queryInterval    time.Duration // block query interval
+	retry            retryConfig   // retry policy for failed block / tx fetches
+	backfillInterval time.Duration // how often queued gaps are re-fetched
+	auditFromHeight  uint64        // lower bound for both audits (skip heights below it)
+	txAuditWindow    int           // heights per tx-audit window (throttle + resume granularity)
+	txAuditNap       time.Duration // pause between tx-audit windows (throttle)
 
-	queryInterval time.Duration // block query interval
-
+	clearOnReset bool // wipe storage when the chain resets
+	auditOnStart bool // scan storage for missing-block gaps on startup
+	txAudit      bool // also scan for blocks with missing txs on startup (expensive)
 }
 
 // New creates a new data fetcher instance
@@ -53,13 +74,20 @@ func New(
 	opts ...Option,
 ) *Fetcher {
 	f := &Fetcher{
-		storage:       storage,
-		client:        client,
-		events:        events,
-		queryInterval: 1 * time.Second,
-		logger:        zap.NewNop(),
-		maxSlots:      DefaultMaxSlots,
-		maxChunkSize:  DefaultMaxChunkSize,
+		storage:          storage,
+		client:           client,
+		events:           events,
+		queryInterval:    1 * time.Second,
+		logger:           zap.NewNop(),
+		maxSlots:         DefaultMaxSlots,
+		maxChunkSize:     DefaultMaxChunkSize,
+		retry:            defaultRetryConfig,
+		gaps:             newGapTracker(),
+		backfillInterval: 0,     // disabled unless explicitly enabled (see WithBackfillInterval)
+		auditOnStart:     false, // enabled alongside the backfiller in production wiring
+		txAudit:          false, // expensive tx-completeness scan, opt-in only
+		txAuditWindow:    DefaultTxAuditWindow,
+		txAuditNap:       DefaultTxAuditNap,
 	}
 
 	for _, opt := range opts {
@@ -80,6 +108,13 @@ func New(
 // blockchain data. The genesis block is not handled here — the genesis
 // package bootstraps it into the storage before any service starts.
 func (f *Fetcher) FetchChainData(ctx context.Context) error {
+
+	// Start the backfiller. It repairs any gaps left behind by failed
+	// fetches / saves (including pre-existing ones already in storage)
+	// without blocking the forward-fetching loop.
+	if f.backfillInterval > 0 {
+		go f.runBackfiller(ctx)
+	}
 
 	collectorCh := make(chan *workerResponse, DefaultMaxSlots)
 
@@ -142,6 +177,8 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 			info := &workerInfo{
 				chunkRange: gap,
 				resCh:      collectorCh,
+				retry:      f.retry,
+				logger:     f.logger,
 			}
 
 			go handleChunk(ctx, f.client, info)
@@ -233,6 +270,24 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 				return f.chunkBuffer.getSlot(i).chunkRange.from >= response.chunkRange.from
 			})
 
+			if response.error != nil {
+				f.logger.Error(
+					"error encountered during chunk fetch",
+					zap.String("error", response.error.Error()),
+				)
+			}
+
+			// The chunk still advances the latest height (so a single bad
+			// block can't stall the fetcher); queueing the missing heights lets
+			// the backfiller revisit them instead of skipping them silently.
+			if len(response.missingBlocks) > 0 {
+				f.gaps.add(response.missingBlocks...)
+
+				f.logger.Warn(
+					"blocks missing after retries, queued for backfill",
+					zap.Uint64s("heights", response.missingBlocks),
+				)
+			}
 			// Save the chunk
 			f.chunkBuffer.setChunk(index, response.chunk)
 
@@ -260,45 +315,7 @@ func (f *Fetcher) writeSlot(s *slot) error {
 	wb := f.storage.WriteBatch()
 
 	// Save the fetched data
-	for blockIndex, block := range s.chunk.blocks {
-		if saveErr := wb.SetBlock(block); saveErr != nil {
-			// This is a design choice that really highlights the strain
-			// of keeping legacy testnets running. Current TM2 testnets
-			// have blocks / transactions that are no longer compatible
-			// with latest "master" changes for Amino, so these blocks / txs are ignored,
-			// as opposed to this error being a show-stopper for the fetcher
-			f.logger.Error("unable to save block", zap.String("err", saveErr.Error()))
-
-			continue
-		}
-
-		f.logger.Debug("Added block data to batch", zap.Int64("number", block.Height))
-
-		// Get block results
-		txResults := s.chunk.results[blockIndex]
-
-		// Save the fetched transaction results
-		for _, txResult := range txResults {
-			if err := wb.SetTx(txResult); err != nil {
-				f.logger.Error("unable to  save tx", zap.String("err", err.Error()))
-
-				continue
-			}
-
-			f.logger.Debug(
-				"Added tx to batch",
-				zap.String("hash", base64.StdEncoding.EncodeToString(txResult.Tx.Hash())),
-			)
-		}
-
-		// Alert any listeners of a new saved block
-		event := &types.NewBlock{
-			Block:   block,
-			Results: txResults,
-		}
-
-		f.events.SignalEvent(event)
-	}
+	failed := f.persistChunk(wb, s.chunk)
 
 	f.logger.Info(
 		"Added to batch block and tx data for range",
@@ -319,9 +336,82 @@ func (f *Fetcher) writeSlot(s *slot) error {
 		return fmt.Errorf("error persisting block information into storage, %w", err)
 	}
 
+	// Queue any block that failed to save for backfill. The latest height has
+	// already advanced past them, so without this they would be lost forever.
+	if len(failed) > 0 {
+		f.gaps.add(failed...)
+
+		f.logger.Warn(
+			"blocks failed to save, queued for backfill",
+			zap.Uint64s("heights", failed),
+		)
+	}
+
 	f.latestChunkSize = len(s.chunk.blocks)
 
 	return nil
+}
+
+// persistChunk writes the chunk's blocks and tx results into the provided
+// batch and signals a NewBlock event for every successfully staged block.
+// It returns the heights of blocks that failed to be staged so the caller can
+// schedule them for backfill. The batch is not committed here.
+func (f *Fetcher) persistChunk(wb storage.Batch, c *chunk) []uint64 {
+	var failed []uint64
+
+	for blockIndex, block := range c.blocks {
+		if saveErr := wb.SetBlock(block); saveErr != nil {
+			// This is a design choice that really highlights the strain
+			// of keeping legacy testnets running. Current TM2 testnets
+			// have blocks / transactions that are no longer compatible
+			// with latest "master" changes for Amino, so these blocks / txs are ignored,
+			// as opposed to this error being a show-stopper for the fetcher
+			f.logger.Error("unable to save block", zap.String("err", saveErr.Error()))
+
+			failed = append(failed, uint64(block.Height))
+
+			continue
+		}
+
+		f.logger.Debug("Added block data to batch", zap.Int64("number", block.Height))
+
+		// Get block results
+		txResults := c.results[blockIndex]
+
+		// Save the fetched transaction results
+		txSaveFailed := false
+
+		for _, txResult := range txResults {
+			if err := wb.SetTx(txResult); err != nil {
+				f.logger.Error("unable to  save tx", zap.String("err", err.Error()))
+
+				txSaveFailed = true
+
+				continue
+			}
+
+			f.logger.Debug(
+				"Added tx to batch",
+				zap.String("hash", base64.StdEncoding.EncodeToString(txResult.Tx.Hash())),
+			)
+		}
+
+		// Block saved but some txs weren't: queue the height for backfill so
+		// the missing txs are recovered instead of left incomplete.
+		if txSaveFailed {
+			failed = append(failed, uint64(block.Height))
+		}
+
+		// Alert any listeners of a new saved block
+		event := &types.NewBlock{
+			Block:   block,
+			Results: txResults,
+		}
+
+		f.events.SignalEvent(event)
+	}
+
+	return failed
 }
 
 func (f *Fetcher) IsReady(ctx context.Context) (bool, error) {

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -316,7 +316,7 @@ func (f *Fetcher) writeSlot(s *slot) error {
 	wb := f.storage.WriteBatch()
 
 	// Save the fetched data
-	failed := f.persistChunk(wb, s.chunk)
+	failed := f.persistChunk(wb, s.chunk, true)
 
 	f.logger.Info(
 		"Added to batch block and tx data for range",
@@ -357,7 +357,7 @@ func (f *Fetcher) writeSlot(s *slot) error {
 // batch and signals a NewBlock event for every successfully staged block.
 // It returns the heights of blocks that failed to be staged so the caller can
 // schedule them for backfill. The batch is not committed here.
-func (f *Fetcher) persistChunk(wb storage.Batch, c *chunk) []uint64 {
+func (f *Fetcher) persistChunk(wb storage.Batch, c *chunk, isSignalEvent bool) []uint64 {
 	var failed []uint64
 
 	for blockIndex, block := range c.blocks {
@@ -409,7 +409,9 @@ func (f *Fetcher) persistChunk(wb storage.Batch, c *chunk) []uint64 {
 			Results: txResults,
 		}
 
-		f.events.SignalEvent(event)
+		if isSignalEvent {
+			f.events.SignalEvent(event)
+		}
 	}
 
 	return failed

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"time"
 
@@ -43,8 +42,6 @@ type Fetcher struct {
 
 	queryInterval time.Duration // block query interval
 
-	dbPath       string
-	clearOnReset bool
 }
 
 // New creates a new data fetcher instance
@@ -83,6 +80,7 @@ func New(
 // blockchain data. The genesis block is not handled here — the genesis
 // package bootstraps it into the storage before any service starts.
 func (f *Fetcher) FetchChainData(ctx context.Context) error {
+
 	collectorCh := make(chan *workerResponse, DefaultMaxSlots)
 
 	// attemptRangeFetch compares local and remote state

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -206,10 +206,14 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 				zap.Uint64("to", gap.to),
 			)
 
-			// Spawn worker
+			// Spawn worker with the same retry policy and logger as the
+			// initial fetch, so a refetch also retries transient failures and
+			// reports the heights it could not recover
 			info := &workerInfo{
 				chunkRange: gap,
 				resCh:      collectorCh,
+				retry:      f.retry,
+				logger:     f.logger,
 			}
 
 			go handleChunk(ctx, f.client, info)
@@ -241,10 +245,13 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 			}
 		case response := <-collectorCh:
 			if response.error != nil {
+				// The missing heights are logged here so a range that keeps
+				// failing can be traced to the block(s) the node cannot serve
 				f.logger.Error(
 					"error encountered during chunk fetch, refetching range",
 					zap.Uint64("from", response.chunkRange.from),
 					zap.Uint64("to", response.chunkRange.to),
+					zap.Uint64s("missingHeights", response.missingBlocks),
 					zap.String("error", response.error.Error()),
 				)
 

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"time"
 
@@ -41,6 +42,9 @@ type Fetcher struct {
 	latestChunkSize int
 
 	queryInterval time.Duration // block query interval
+
+	dbPath       string
+	clearOnReset bool
 }
 
 // New creates a new data fetcher instance
@@ -105,8 +109,21 @@ func (f *Fetcher) FetchChainData(ctx context.Context) error {
 		}
 
 		// Check if there is a block gap
-		if latestRemote <= latestLocal {
+		if latestRemote == latestLocal {
 			// No gap, nothing to sync
+			return nil
+		}
+
+		// Check if there is reset chains
+		if latestRemote < latestLocal {
+			if f.clearOnReset {
+				if err := os.RemoveAll(f.dbPath); err != nil {
+					return fmt.Errorf("unable to remove DB, %w", err)
+				}
+
+				return fmt.Errorf("reset chain: latestRemote(%d) < latestLocal(%d)", latestRemote, latestLocal)
+			}
+
 			return nil
 		}
 

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -362,7 +362,8 @@ func TestFetcher_FetchTransactions_Valid_FullBlocks(t *testing.T) {
 								t.Fatalf("invalid block requested, %d", num)
 							}
 
-							batch = append(batch,
+							batch = append(
+								batch,
 								&core_types.ResultBlockResults{
 									Height: int64(num),
 									Results: &state.ABCIResponses{

--- a/fetch/options.go
+++ b/fetch/options.go
@@ -28,3 +28,17 @@ func WithMaxChunkSize(maxChunkSize int64) Option {
 		f.latestChunkSize = int(maxChunkSize)
 	}
 }
+
+// WithClearOnReset sets the clear on reset flag
+func WithClearOnReset(clearOnReset bool) Option {
+	return func(f *Fetcher) {
+		f.clearOnReset = clearOnReset
+	}
+}
+
+// WithDBPath sets the database path
+func WithDBPath(dbPath string) Option {
+	return func(f *Fetcher) {
+		f.dbPath = dbPath
+	}
+}

--- a/fetch/options.go
+++ b/fetch/options.go
@@ -1,6 +1,10 @@
 package fetch
 
-import "go.uber.org/zap"
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
 
 type Option func(f *Fetcher)
 
@@ -40,5 +44,65 @@ func WithClearOnReset(clearOnReset bool) Option {
 func WithDBPath(dbPath string) Option {
 	return func(f *Fetcher) {
 		f.dbPath = dbPath
+	}
+}
+
+// WithChunkFetchRetry configures how failed block / tx-result fetches are retried.
+// Only the heights that fail are retried; already-fetched blocks are kept.
+// maxRetries is the number of retry rounds, each preceded by delay.
+func WithChunkFetchRetry(maxRetries int, delay time.Duration) Option {
+	return func(f *Fetcher) {
+		f.retry = retryConfig{
+			maxRetries: maxRetries,
+			retryDelay: delay,
+		}
+	}
+}
+
+// WithBackfillInterval sets how often the backfiller drains queued gaps.
+// A non-positive interval disables the backfiller entirely.
+func WithBackfillInterval(interval time.Duration) Option {
+	return func(f *Fetcher) {
+		f.backfillInterval = interval
+	}
+}
+
+// WithStartupAudit controls whether the backfiller scans existing storage for
+// missing-block gaps on startup.
+func WithStartupAudit(enabled bool) Option {
+	return func(f *Fetcher) {
+		f.auditOnStart = enabled
+	}
+}
+
+// WithTxAudit controls whether the startup audit also queues blocks
+// that are stored but missing some or all of their transactions.
+// It must decode every block to read the declared tx count,
+// so it is much more expensive than the plain missing-block audit and is opt-in.
+func WithTxAudit(enabled bool) Option {
+	return func(f *Fetcher) {
+		f.txAudit = enabled
+	}
+}
+
+// WithAuditFromHeight limits both startup audits to heights >= from, skipping
+// everything below it. Use it to scan only the range affected by an incident
+// instead of the whole history.
+func WithAuditFromHeight(from uint64) Option {
+	return func(f *Fetcher) {
+		f.auditFromHeight = from
+	}
+}
+
+// WithTxAuditThrottle tunes the tx-completeness audit for constrained
+// deployments: it processes windowBlocks heights, then pauses for nap before
+// the next window. A smaller window and larger nap lower the audit's CPU share
+// (at the cost of a longer scan). The window is also the resume granularity:
+// progress is persisted per completed window so restarts continue instead of
+// re-scanning from the start.
+func WithTxAuditThrottle(windowBlocks int, nap time.Duration) Option {
+	return func(f *Fetcher) {
+		f.txAuditWindow = windowBlocks
+		f.txAuditNap = nap
 	}
 }

--- a/fetch/options.go
+++ b/fetch/options.go
@@ -94,6 +94,16 @@ func WithAuditFromHeight(from uint64) Option {
 	}
 }
 
+// WithTxAuditReset makes the tx-completeness audit ignore the persisted
+// watermark and re-scan from WithAuditFromHeight, overwriting the watermark as
+// the fresh scan progresses. Use it to force a re-check of a range that was
+// already marked audited.
+func WithTxAuditReset(enabled bool) Option {
+	return func(f *Fetcher) {
+		f.txAuditReset = enabled
+	}
+}
+
 // WithTxAuditThrottle tunes the tx-completeness audit for constrained
 // deployments: it processes windowBlocks heights, then pauses for nap before
 // the next window. A smaller window and larger nap lower the audit's CPU share

--- a/fetch/worker.go
+++ b/fetch/worker.go
@@ -4,58 +4,308 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"time"
 
 	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"go.uber.org/zap"
 )
+
+// retryConfig controls how failed block / tx-result fetches are retried.
+// Only the heights that actually failed are retried; already-fetched
+// blocks are kept.
+type retryConfig struct {
+	maxRetries int           // number of retry rounds for missing heights
+	retryDelay time.Duration // fixed wait between retry rounds
+}
+
+// defaultRetryConfig retries missing heights up to 5 times, waiting 2s between
+// rounds. Sized to ride out short RPC blips (e.g. a 502) without hammering an
+// unhealthy node. Tune via WithChunkFetchRetry.
+var defaultRetryConfig = retryConfig{
+	maxRetries: 5,
+	retryDelay: 2 * time.Second,
+}
+
+// sleepWithContext sleeps for d, returning early if the context is cancelled.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
 
 // workerInfo is the work context for the fetch routine
 type workerInfo struct {
-	resCh      chan<- *workerResponse // response channel
-	chunkRange chunkRange             // data range
+	resCh      chan<- *workerResponse
+	logger     *zap.Logger // may be nil
+	chunkRange chunkRange
+	retry      retryConfig
 }
 
 // workerResponse is the routine response
 type workerResponse struct {
-	error      error      // encountered error, if any
-	chunk      *chunk     // the fetched chunk
-	chunkRange chunkRange // the fetched chunk range
+	error error
+	chunk *chunk
+
+	// missingBlocks are heights in the range still unavailable after retries,
+	// to be scheduled for backfill rather than skipped.
+	missingBlocks []uint64
+
+	chunkRange chunkRange
 }
 
-// handleChunk fetches the chunk from the client
+// handleChunk fetches the chunk, retrying failed heights so transient RPC
+// errors do not silently drop blocks. Heights still unavailable after all
+// retries are reported in missingBlocks for later backfill.
 func handleChunk(
 	ctx context.Context,
 	client Client,
 	info *workerInfo,
 ) {
-	extractChunk := func() (*chunk, error) {
-		errs := make([]error, 0, 2)
-
-		// Get block data from the node
-		blocks, err := getBlocksFromBatch(ctx, info.chunkRange, client)
-		errs = append(errs, err)
-
-		results, err := getTxResultFromBatch(ctx, blocks, client)
-		errs = append(errs, err)
-
-		return &chunk{
-			blocks:  blocks,
-			results: results,
-		}, errors.Join(errs...)
+	logger := info.logger
+	if logger == nil {
+		logger = zap.NewNop()
 	}
 
-	c, err := extractChunk()
+	c, missing, err := fetchChunk(ctx, client, info.chunkRange, info.retry, logger)
 
 	response := &workerResponse{
-		error:      err,
-		chunk:      c,
-		chunkRange: info.chunkRange,
+		error:         err,
+		chunk:         c,
+		chunkRange:    info.chunkRange,
+		missingBlocks: missing,
 	}
 
 	select {
 	case <-ctx.Done():
 	case info.resCh <- response:
 	}
+}
+
+// fetchChunk fetches the blocks and tx results for the range, retrying only
+// the heights that fail. The returned chunk holds only fully-fetched blocks
+// (block + tx results); heights that could not be completed are returned in
+// missing for later backfill.
+func fetchChunk(
+	ctx context.Context,
+	client Client,
+	r chunkRange,
+	retry retryConfig,
+	logger *zap.Logger,
+) (*chunk, []uint64, error) {
+	blocks := fetchBlocksWithRetry(ctx, client, r, retry, logger)
+
+	// A block whose results can't be fetched is dropped from the chunk (and
+	// reported as missing), so it is re-fetched whole later rather than
+	// persisted without its transactions.
+	results, incomplete := fetchResultsWithRetry(ctx, client, blocks, retry, logger)
+
+	completeBlocks := make([]*types.Block, 0, len(blocks))
+	completeResults := make([][]*types.TxResult, 0, len(blocks))
+
+	for i, block := range blocks {
+		if incomplete[i] {
+			continue
+		}
+
+		completeBlocks = append(completeBlocks, block)
+		completeResults = append(completeResults, results[i])
+	}
+
+	have := make(map[uint64]struct{}, len(completeBlocks))
+	for _, block := range completeBlocks {
+		have[uint64(block.Height)] = struct{}{}
+	}
+
+	missing := missingHeights(r, have)
+
+	var err error
+	if len(missing) > 0 {
+		err = fmt.Errorf("unable to fully fetch %d block(s) in range [%d, %d]", len(missing), r.from, r.to)
+	}
+
+	return &chunk{
+		blocks:  completeBlocks,
+		results: completeResults,
+	}, missing, err
+}
+
+// missingHeights returns the heights in the range absent from have, ascending.
+func missingHeights[V any](r chunkRange, have map[uint64]V) []uint64 {
+	var missing []uint64
+
+	for h := r.from; h <= r.to; h++ {
+		if _, ok := have[h]; !ok {
+			missing = append(missing, h)
+		}
+	}
+
+	return missing
+}
+
+// fetchBlocksWithRetry fetches all blocks in the range, retrying only the
+// heights that fail and keeping the ones already fetched. The result is sorted
+// by height ascending.
+func fetchBlocksWithRetry(
+	ctx context.Context,
+	client Client,
+	r chunkRange,
+	retry retryConfig,
+	logger *zap.Logger,
+) []*types.Block {
+	have := make(map[uint64]*types.Block)
+
+	// First pass: batch fetch (falls back to sequential internally), keeping
+	// whatever partial results come back.
+	// The error is intentionally ignored:
+	// any heights missing from the partial result are retried below.
+	blocks, _ := getBlocksFromBatch(ctx, r, client) //nolint:errcheck // partial results retried below
+	for _, block := range blocks {
+		have[uint64(block.Height)] = block
+	}
+
+	missing := missingHeights(r, have)
+
+	for attempt := 0; len(missing) > 0 && attempt < retry.maxRetries; attempt++ {
+		if err := sleepWithContext(ctx, retry.retryDelay); err != nil {
+			break // context cancelled
+		}
+
+		logger.Warn(
+			"retrying missing blocks",
+			zap.Int("attempt", attempt+1),
+			zap.Int("count", len(missing)),
+			zap.Uint64("from", r.from),
+			zap.Uint64("to", r.to),
+		)
+
+		for _, height := range missing {
+			block, err := client.GetBlock(ctx, height)
+			if err != nil {
+				continue
+			}
+
+			have[height] = block.Block
+		}
+
+		missing = missingHeights(r, have)
+	}
+
+	return sortedBlocks(have)
+}
+
+// sortedBlocks returns the map's blocks sorted by height ascending.
+func sortedBlocks(have map[uint64]*types.Block) []*types.Block {
+	blocks := make([]*types.Block, 0, len(have))
+	for _, block := range have {
+		blocks = append(blocks, block)
+	}
+
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].Height < blocks[j].Height
+	})
+
+	return blocks
+}
+
+// fetchResultsWithRetry fetches tx results for the blocks, retrying only the
+// ones that fail. It returns the results aligned to the blocks slice, plus the
+// set (by block index) whose results are still missing after retries.
+func fetchResultsWithRetry(
+	ctx context.Context,
+	client Client,
+	blocks []*types.Block,
+	retry retryConfig,
+	logger *zap.Logger,
+) ([][]*types.TxResult, map[int]bool) {
+	// First pass: batch fetch (falls back to sequential internally).
+	// The error is intentionally ignored:
+	// any blocks whose results are missing are retried below.
+	results, _ := getTxResultFromBatch(ctx, blocks, client) //nolint:errcheck // missing results retried below
+	if results == nil {
+		results = make([][]*types.TxResult, len(blocks))
+	}
+
+	incomplete := make(map[int]bool)
+
+	for i, block := range blocks {
+		if block.NumTxs > 0 && results[i] == nil {
+			incomplete[i] = true
+		}
+	}
+
+	// Retry rounds: only re-request the blocks whose results are still missing
+	for attempt := 0; len(incomplete) > 0 && attempt < retry.maxRetries; attempt++ {
+		if err := sleepWithContext(ctx, retry.retryDelay); err != nil {
+			break
+		}
+
+		logger.Warn(
+			"retrying missing tx results",
+			zap.Int("attempt", attempt+1),
+			zap.Int("count", len(incomplete)),
+		)
+
+		for i := range incomplete {
+			block := blocks[i]
+
+			blockResults, err := client.GetBlockResults(ctx, uint64(block.Height))
+			if err != nil {
+				continue
+			}
+
+			txResults, err := buildTxResults(block, blockResults)
+			if err != nil {
+				continue
+			}
+
+			results[i] = txResults
+			delete(incomplete, i)
+		}
+	}
+
+	return results, incomplete
+}
+
+// buildTxResults assembles the per-tx results for a block from the block
+// results response.
+func buildTxResults(block *types.Block, blockResults *core_types.ResultBlockResults) ([]*types.TxResult, error) {
+	if blockResults == nil || blockResults.Results == nil {
+		return nil, errors.New("nil block results")
+	}
+
+	deliverTxs := blockResults.Results.DeliverTxs
+	if len(deliverTxs) < len(block.Txs) {
+		return nil, fmt.Errorf(
+			"block %d results count mismatch: got %d, want %d",
+			block.Height,
+			len(deliverTxs),
+			len(block.Txs),
+		)
+	}
+
+	txResults := make([]*types.TxResult, block.NumTxs)
+	for txIndex, tx := range block.Txs {
+		txResults[txIndex] = &types.TxResult{
+			Height:   block.Height,
+			Index:    uint32(txIndex),
+			Tx:       tx,
+			Response: deliverTxs[txIndex],
+		}
+	}
+
+	return txResults, nil
 }
 
 // getBlocksFromBatch gets the blocks using batch requests.
@@ -175,7 +425,6 @@ func getTxResultFromBatch(ctx context.Context, blocks []*types.Block, client Cli
 		}
 
 		height := results.Height
-		deliverTxs := results.Results.DeliverTxs
 
 		blockIndex, found := indexOfBlockHeight[height]
 		if !found {
@@ -185,17 +434,9 @@ func getTxResultFromBatch(ctx context.Context, blocks []*types.Block, client Cli
 			)
 		}
 
-		txResults := make([]*types.TxResult, blocks[blockIndex].NumTxs)
-
-		for txIndex, tx := range blocks[blockIndex].Txs {
-			result := &types.TxResult{
-				Height:   height,
-				Index:    uint32(txIndex),
-				Tx:       tx,
-				Response: deliverTxs[txIndex],
-			}
-
-			txResults[txIndex] = result
+		txResults, err := buildTxResults(blocks[blockIndex], results)
+		if err != nil {
+			return nil, err
 		}
 
 		// Empty blocks are left out of the results batch, so its responses are
@@ -236,17 +477,11 @@ func getTxResultsSequentially(ctx context.Context, blocks []*types.Block, client
 		}
 
 		// Save the transaction result
-		txResults := make([]*types.TxResult, block.NumTxs)
+		txResults, err := buildTxResults(block, blockResults)
+		if err != nil {
+			errs = append(errs, err)
 
-		for index, tx := range block.Txs {
-			result := &types.TxResult{
-				Height:   block.Height,
-				Index:    uint32(index),
-				Tx:       tx,
-				Response: blockResults.Results.DeliverTxs[index],
-			}
-
-			txResults[index] = result
+			continue
 		}
 
 		results[index] = txResults

--- a/fetch/worker_test.go
+++ b/fetch/worker_test.go
@@ -1,0 +1,266 @@
+package fetch
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
+	core_types "github.com/gnolang/gno/tm2/pkg/bft/rpc/core/types"
+	"github.com/gnolang/gno/tm2/pkg/bft/state"
+	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// mockBlockResults builds a block results response with numTxs deliver results.
+func mockBlockResults(height int64, numTxs int) *core_types.ResultBlockResults {
+	return &core_types.ResultBlockResults{
+		Height: height,
+		Results: &state.ABCIResponses{
+			DeliverTxs: make([]abci.ResponseDeliverTx, numTxs),
+		},
+	}
+}
+
+// blockHeightsOf returns the heights of the given blocks, in order.
+func blockHeightsOf(blocks []*types.Block) []int64 {
+	heights := make([]int64, 0, len(blocks))
+	for _, block := range blocks {
+		heights = append(heights, block.Height)
+	}
+
+	return heights
+}
+
+func TestFetchBlocksWithRetry(t *testing.T) {
+	t.Parallel()
+
+	txs := generateTransactions(t, 0) // empty blocks keep this focused on block fetching
+	blocks := generateBlocks(t, 6, txs)
+
+	t.Run("keeps successful blocks and retries only the failed height", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			mu    sync.Mutex
+			calls = make(map[uint64]int)
+		)
+
+		client := &mockClient{
+			createBatchFn: erroringBatch,
+			getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+				mu.Lock()
+				calls[num]++
+				attempt := calls[num]
+				mu.Unlock()
+
+				// Height 3 fails on its first two attempts, then succeeds
+				if num == 3 && attempt < 3 {
+					return nil, errors.New("flaky 502")
+				}
+
+				return &core_types.ResultBlock{Block: blocks[num]}, nil
+			},
+		}
+
+		result := fetchBlocksWithRetry(context.Background(), client, chunkRange{from: 1, to: 5}, fastRetry, zap.NewNop())
+
+		require.Equal(t, []int64{1, 2, 3, 4, 5}, blockHeightsOf(result))
+
+		// Only the failing height was retried; the rest were fetched exactly once
+		mu.Lock()
+		defer mu.Unlock()
+
+		assert.Equal(t, 3, calls[3])
+
+		for _, h := range []uint64{1, 2, 4, 5} {
+			assert.Equal(t, 1, calls[h], "height %d should not be retried", h)
+		}
+	})
+
+	t.Run("returns a partial set when a height never succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		client := &mockClient{
+			createBatchFn: erroringBatch,
+			getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+				if num == 4 {
+					return nil, errors.New("permanently gone")
+				}
+
+				return &core_types.ResultBlock{Block: blocks[num]}, nil
+			},
+		}
+
+		result := fetchBlocksWithRetry(context.Background(), client, chunkRange{from: 1, to: 5}, fastRetry, zap.NewNop())
+
+		// Height 4 is absent, the rest are present and sorted
+		assert.Equal(t, []int64{1, 2, 3, 5}, blockHeightsOf(result))
+	})
+}
+
+func TestFetchChunk(t *testing.T) {
+	t.Parallel()
+
+	const txCount = 1
+
+	txs := generateTransactions(t, txCount)
+	blocks := generateBlocks(t, 6, txs)
+
+	// alwaysBlocks serves every block in the range successfully. The error
+	// return is required by getBlockDelegate even though it is always nil.
+	alwaysBlocks := func(num uint64) (*core_types.ResultBlock, error) { //nolint:unparam // delegate signature
+		return &core_types.ResultBlock{Block: blocks[num]}, nil
+	}
+
+	testTable := []struct {
+		name            string
+		buildClient     func() *mockClient
+		expectedHeights []int64
+		expectedMissing []uint64
+	}{
+		{
+			"all blocks and results fetched",
+			func() *mockClient {
+				return &mockClient{
+					createBatchFn: erroringBatch,
+					getBlockFn:    alwaysBlocks,
+					getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+						return mockBlockResults(int64(num), txCount), nil
+					},
+				}
+			},
+			[]int64{2, 3, 4, 5},
+			nil,
+		},
+		{
+			"block that never fetches is reported missing",
+			func() *mockClient {
+				return &mockClient{
+					createBatchFn: erroringBatch,
+					getBlockFn: func(num uint64) (*core_types.ResultBlock, error) {
+						if num == 4 {
+							return nil, errors.New("permanently gone")
+						}
+
+						return &core_types.ResultBlock{Block: blocks[num]}, nil
+					},
+					getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+						return mockBlockResults(int64(num), txCount), nil
+					},
+				}
+			},
+			[]int64{2, 3, 5},
+			[]uint64{4},
+		},
+		{
+			"tx results are retried and then succeed",
+			func() *mockClient {
+				var (
+					mu    sync.Mutex
+					calls = make(map[uint64]int)
+				)
+
+				return &mockClient{
+					createBatchFn: erroringBatch,
+					getBlockFn:    alwaysBlocks,
+					getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+						mu.Lock()
+						calls[num]++
+						attempt := calls[num]
+						mu.Unlock()
+
+						// Height 4 results fail once, then succeed
+						if num == 4 && attempt < 2 {
+							return nil, errors.New("flaky results")
+						}
+
+						return mockBlockResults(int64(num), txCount), nil
+					},
+				}
+			},
+			[]int64{2, 3, 4, 5},
+			nil,
+		},
+		{
+			"block whose results never fetch is dropped and reported missing",
+			func() *mockClient {
+				return &mockClient{
+					createBatchFn: erroringBatch,
+					getBlockFn:    alwaysBlocks,
+					getBlockResultsFn: func(num uint64) (*core_types.ResultBlockResults, error) {
+						if num == 4 {
+							return nil, errors.New("results permanently gone")
+						}
+
+						return mockBlockResults(int64(num), txCount), nil
+					},
+				}
+			},
+			[]int64{2, 3, 5},
+			[]uint64{4},
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, missing, err := fetchChunk(
+				context.Background(),
+				testCase.buildClient(),
+				chunkRange{from: 2, to: 5},
+				fastRetry,
+				zap.NewNop(),
+			)
+
+			assert.Equal(t, testCase.expectedHeights, blockHeightsOf(c.blocks))
+			assert.Equal(t, testCase.expectedMissing, missing)
+
+			if len(testCase.expectedMissing) > 0 {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBuildTxResults(t *testing.T) {
+	t.Parallel()
+
+	txCount := 3
+	txs := generateTransactions(t, txCount)
+	block := generateBlocks(t, 2, txs)[1] // block with txCount txs
+
+	t.Run("nil results", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := buildTxResults(block, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("fewer deliver results than txs", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := buildTxResults(block, mockBlockResults(block.Height, txCount-1))
+		assert.Error(t, err)
+	})
+
+	t.Run("builds one result per tx", func(t *testing.T) {
+		t.Parallel()
+
+		results, err := buildTxResults(block, mockBlockResults(block.Height, txCount))
+		require.NoError(t, err)
+		require.Len(t, results, txCount)
+
+		for index, result := range results {
+			assert.Equal(t, block.Height, result.Height)
+			assert.EqualValues(t, index, result.Index)
+			assert.Equal(t, block.Txs[index], result.Tx)
+		}
+	})
+}

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"time"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
@@ -100,6 +103,11 @@ func bootstrap(ctx context.Context, store Storage, client Client, cfg *config) e
 	cfg.logger.Info("Fetching genesis")
 
 	doc, state, err := fetchState(ctx, client)
+	if err != nil && cfg.genesisURL != "" {
+		cfg.logger.Warn("RPC genesis fetch failed; falling back to configured URL", zap.Error(err))
+
+		doc, state, err = fetchStateFromURL(ctx, cfg.genesisURL)
+	}
 	if err != nil {
 		return err
 	}
@@ -242,6 +250,63 @@ func fetchState(
 	}
 
 	return gblock.Genesis, state, nil
+}
+
+func fetchStateFromURL(
+	ctx context.Context,
+	url string,
+) (*bft_types.GenesisDoc, gnoland.GnoGenesisState, error) {
+	tmpFile, err := os.CreateTemp("", "genesis-*.json")
+	if err != nil {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to create temporary genesis file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		tmpFile.Close()
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to create genesis request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		tmpFile.Close()
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to fetch genesis URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		tmpFile.Close()
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unexpected genesis URL status: %s", resp.Status)
+	}
+
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		tmpFile.Close()
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to download genesis: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to close downloaded genesis: %w", err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to read downloaded genesis: %w", err)
+	}
+
+	var doc bft_types.GenesisDoc
+	if err := amino.UnmarshalJSON(data, &doc); err != nil {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to parse downloaded genesis: %w", err)
+	}
+
+	state, ok := doc.AppState.(gnoland.GnoGenesisState)
+	if !ok {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf(
+			"%w: unknown genesis state kind '%T'", ErrInvalidState, doc.AppState,
+		)
+	}
+
+	return &doc, state, nil
 }
 
 // blockFrom builds the genesis block from the decoded state. It marshals every

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -7,11 +7,14 @@ package genesis
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/gnolang/gno/gno.land/pkg/gnoland"
@@ -294,6 +297,11 @@ func fetchStateFromURL(
 		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to read downloaded genesis: %w", err)
 	}
 
+	data, err = sanitizeGenesisTxMetadata(data)
+	if err != nil {
+		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to sanitize downloaded genesis: %w", err)
+	}
+
 	var doc bft_types.GenesisDoc
 	if err := amino.UnmarshalJSON(data, &doc); err != nil {
 		return nil, gnoland.GnoGenesisState{}, fmt.Errorf("unable to parse downloaded genesis: %w", err)
@@ -307,6 +315,92 @@ func fetchStateFromURL(
 	}
 
 	return &doc, state, nil
+}
+
+func sanitizeGenesisTxMetadata(data []byte) ([]byte, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("unable to decode genesis document: %w", err)
+	}
+
+	appStateRaw, ok := doc["app_state"]
+	if !ok {
+		return data, nil
+	}
+
+	var appState map[string]json.RawMessage
+	if err := json.Unmarshal(appStateRaw, &appState); err != nil {
+		return nil, fmt.Errorf("unable to decode app_state: %w", err)
+	}
+
+	txsRaw, ok := appState["txs"]
+	if !ok {
+		return data, nil
+	}
+
+	var txs []map[string]json.RawMessage
+	if err := json.Unmarshal(txsRaw, &txs); err != nil {
+		return nil, fmt.Errorf("unable to decode genesis txs: %w", err)
+	}
+
+	known := knownJSONFields(reflect.TypeOf(gnoland.GnoTxMetadata{}))
+	changed := false
+	for _, tx := range txs {
+		metaRaw, ok := tx["metadata"]
+		if !ok {
+			continue
+		}
+
+		var meta map[string]json.RawMessage
+		if err := json.Unmarshal(metaRaw, &meta); err != nil {
+			return nil, fmt.Errorf("unable to decode genesis tx metadata: %w", err)
+		}
+
+		for key := range meta {
+			if !known[key] {
+				delete(meta, key)
+				changed = true
+			}
+		}
+
+		cleaned, err := json.Marshal(meta)
+		if err != nil {
+			return nil, fmt.Errorf("unable to re-encode tx metadata: %w", err)
+		}
+		tx["metadata"] = cleaned
+	}
+
+	if !changed {
+		return data, nil
+	}
+
+	newTxs, err := json.Marshal(txs)
+	if err != nil {
+		return nil, fmt.Errorf("unable to re-encode genesis txs: %w", err)
+	}
+	appState["txs"] = newTxs
+
+	newAppState, err := json.Marshal(appState)
+	if err != nil {
+		return nil, fmt.Errorf("unable to re-encode app_state: %w", err)
+	}
+	doc["app_state"] = newAppState
+
+	return json.Marshal(doc)
+}
+
+func knownJSONFields(t reflect.Type) map[string]bool {
+	fields := make(map[string]bool, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		name := strings.Split(tag, ",")[0]
+		if name == "" || name == "-" {
+			name = t.Field(i).Name
+		}
+		fields[name] = true
+	}
+
+	return fields
 }
 
 // blockFrom builds the genesis block from the decoded state. It marshals every

--- a/genesis/options.go
+++ b/genesis/options.go
@@ -9,8 +9,9 @@ import (
 type Option func(c *config)
 
 type config struct {
-	logger  *zap.Logger
-	backoff time.Duration
+	logger     *zap.Logger
+	backoff    time.Duration
+	genesisURL string
 }
 
 // WithLogger sets the logger to be used with the bootstrap
@@ -24,5 +25,12 @@ func WithLogger(logger *zap.Logger) Option {
 func WithBackoff(backoff time.Duration) Option {
 	return func(c *config) {
 		c.backoff = backoff
+	}
+}
+
+// WithURL sets the fallback URL to download genesis.json when the RPC call fails.
+func WithURL(url string) Option {
+	return func(c *config) {
+		c.genesisURL = url
 	}
 }

--- a/internal/mock/storage.go
+++ b/internal/mock/storage.go
@@ -18,6 +18,28 @@ type Storage struct {
 	GetBlockFn             func(uint64) (*types.Block, error)
 	GetTxFn                func(uint64, uint32) (*types.TxResult, error)
 	GetTxByHashFn          func(string) (*types.TxResult, error)
+	BlockIteratorFn        func(uint64, uint64) (storage.Iterator[*types.Block], error)
+	TxIteratorFn           func(uint64, uint64, uint32, uint32) (storage.Iterator[*types.TxResult], error)
+	GetTxAuditHeightFn     func() (uint64, error)
+	SetTxAuditHeightFn     func(uint64) error
+}
+
+// GetTxAuditHeight returns the stored tx-audit watermark
+func (m *Storage) GetTxAuditHeight() (uint64, error) {
+	if m.GetTxAuditHeightFn != nil {
+		return m.GetTxAuditHeightFn()
+	}
+
+	return 0, storageErrors.ErrNotFound
+}
+
+// SetTxAuditHeight records the tx-audit watermark
+func (m *Storage) SetTxAuditHeight(height uint64) error {
+	if m.SetTxAuditHeightFn != nil {
+		return m.SetTxAuditHeightFn(height)
+	}
+
+	return nil
 }
 
 func (m *Storage) GetLatestHeight() (uint64, error) {
@@ -75,19 +97,93 @@ func (m *Storage) GetTxByHash(txHash string) (*types.TxResult, error) {
 }
 
 // BlockIterator iterates over Blocks, limiting the results to be between the provided block numbers
-func (m *Storage) BlockIterator(_, _ uint64) (storage.Iterator[*types.Block], error) {
+func (m *Storage) BlockIterator(fromBlockNum, toBlockNum uint64) (storage.Iterator[*types.Block], error) {
+	if m.BlockIteratorFn != nil {
+		return m.BlockIteratorFn(fromBlockNum, toBlockNum)
+	}
+
 	panic("not implemented") // TODO: Implement
+}
+
+// SliceBlockIterator is a simple in-memory Iterator[*types.Block] backed by a
+// slice of blocks, intended for tests.
+type SliceBlockIterator struct {
+	blocks []*types.Block
+	index  int
+}
+
+// NewSliceBlockIterator returns an iterator over the provided blocks.
+func NewSliceBlockIterator(blocks []*types.Block) *SliceBlockIterator {
+	return &SliceBlockIterator{
+		blocks: blocks,
+		index:  -1,
+	}
+}
+
+func (it *SliceBlockIterator) Next() bool {
+	it.index++
+
+	return it.index < len(it.blocks)
+}
+
+func (it *SliceBlockIterator) Error() error {
+	return nil
+}
+
+func (it *SliceBlockIterator) Value() (*types.Block, error) {
+	return it.blocks[it.index], nil
+}
+
+func (it *SliceBlockIterator) Close() error {
+	return nil
 }
 
 // TxIterator iterates over transactions, limiting the results to be between the provided block numbers
 // and transaction indexes
 func (m *Storage) TxIterator(
-	_,
-	_ uint64,
-	_,
-	_ uint32,
+	fromBlockNum,
+	toBlockNum uint64,
+	fromTxIndex,
+	toTxIndex uint32,
 ) (storage.Iterator[*types.TxResult], error) {
+	if m.TxIteratorFn != nil {
+		return m.TxIteratorFn(fromBlockNum, toBlockNum, fromTxIndex, toTxIndex)
+	}
+
 	panic("not implemented") // TODO: Implement
+}
+
+// SliceTxIterator is a simple in-memory Iterator[*types.TxResult] backed by a
+// slice of tx results, intended for tests.
+type SliceTxIterator struct {
+	txs   []*types.TxResult
+	index int
+}
+
+// NewSliceTxIterator returns an iterator over the provided tx results.
+func NewSliceTxIterator(txs []*types.TxResult) *SliceTxIterator {
+	return &SliceTxIterator{
+		txs:   txs,
+		index: -1,
+	}
+}
+
+func (it *SliceTxIterator) Next() bool {
+	it.index++
+
+	return it.index < len(it.txs)
+}
+
+func (it *SliceTxIterator) Error() error {
+	return nil
+}
+
+func (it *SliceTxIterator) Value() (*types.TxResult, error) {
+	return it.txs[it.index], nil
+}
+
+func (it *SliceTxIterator) Close() error {
+	return nil
 }
 
 func (m *Storage) BlockReverseIterator(_, _ uint64) (storage.Iterator[*types.Block], error) {

--- a/serve/graph/generated.go
+++ b/serve/graph/generated.go
@@ -114,6 +114,24 @@ type ComplexityRoot struct {
 		Send       func(childComplexity int) int
 	}
 
+	MsgCreateSession struct {
+		AllowPaths  func(childComplexity int) int
+		Creator     func(childComplexity int) int
+		ExpiresAt   func(childComplexity int) int
+		SessionKey  func(childComplexity int) int
+		SpendLimit  func(childComplexity int) int
+		SpendPeriod func(childComplexity int) int
+	}
+
+	MsgRevokeAllSessions struct {
+		Creator func(childComplexity int) int
+	}
+
+	MsgRevokeSession struct {
+		Creator    func(childComplexity int) int
+		SessionKey func(childComplexity int) int
+	}
+
 	MsgRun struct {
 		Caller     func(childComplexity int) int
 		MaxDeposit func(childComplexity int) int
@@ -128,6 +146,12 @@ type ComplexityRoot struct {
 		GetTransactions   func(childComplexity int, where model.FilterTransaction, order *model.TransactionOrder) int
 		LatestBlockHeight func(childComplexity int) int
 		Transactions      func(childComplexity int, filter model.TransactionFilter) int
+	}
+
+	Signature struct {
+		PubKey      func(childComplexity int) int
+		SessionAddr func(childComplexity int) int
+		Signature   func(childComplexity int) int
 	}
 
 	StorageDepositEvent struct {
@@ -170,6 +194,7 @@ type ComplexityRoot struct {
 		Memo        func(childComplexity int) int
 		Messages    func(childComplexity int) int
 		Response    func(childComplexity int) int
+		Signatures  func(childComplexity int) int
 		Success     func(childComplexity int) int
 	}
 
@@ -522,6 +547,63 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.MsgCall.Send(childComplexity), true
 
+	case "MsgCreateSession.allow_paths":
+		if e.ComplexityRoot.MsgCreateSession.AllowPaths == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgCreateSession.AllowPaths(childComplexity), true
+	case "MsgCreateSession.creator":
+		if e.ComplexityRoot.MsgCreateSession.Creator == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgCreateSession.Creator(childComplexity), true
+	case "MsgCreateSession.expires_at":
+		if e.ComplexityRoot.MsgCreateSession.ExpiresAt == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgCreateSession.ExpiresAt(childComplexity), true
+	case "MsgCreateSession.session_key":
+		if e.ComplexityRoot.MsgCreateSession.SessionKey == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgCreateSession.SessionKey(childComplexity), true
+	case "MsgCreateSession.spend_limit":
+		if e.ComplexityRoot.MsgCreateSession.SpendLimit == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgCreateSession.SpendLimit(childComplexity), true
+	case "MsgCreateSession.spend_period":
+		if e.ComplexityRoot.MsgCreateSession.SpendPeriod == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgCreateSession.SpendPeriod(childComplexity), true
+
+	case "MsgRevokeAllSessions.creator":
+		if e.ComplexityRoot.MsgRevokeAllSessions.Creator == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgRevokeAllSessions.Creator(childComplexity), true
+
+	case "MsgRevokeSession.creator":
+		if e.ComplexityRoot.MsgRevokeSession.Creator == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgRevokeSession.Creator(childComplexity), true
+	case "MsgRevokeSession.session_key":
+		if e.ComplexityRoot.MsgRevokeSession.SessionKey == nil {
+			break
+		}
+
+		return e.ComplexityRoot.MsgRevokeSession.SessionKey(childComplexity), true
+
 	case "MsgRun.caller":
 		if e.ComplexityRoot.MsgRun.Caller == nil {
 			break
@@ -609,6 +691,25 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.Transactions(childComplexity, args["filter"].(model.TransactionFilter)), true
+
+	case "Signature.pub_key":
+		if e.ComplexityRoot.Signature.PubKey == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Signature.PubKey(childComplexity), true
+	case "Signature.session_addr":
+		if e.ComplexityRoot.Signature.SessionAddr == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Signature.SessionAddr(childComplexity), true
+	case "Signature.signature":
+		if e.ComplexityRoot.Signature.Signature == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Signature.Signature(childComplexity), true
 
 	case "StorageDepositEvent.bytes_delta":
 		if e.ComplexityRoot.StorageDepositEvent.BytesDelta == nil {
@@ -796,6 +897,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Transaction.Response(childComplexity), true
+	case "Transaction.signatures":
+		if e.ComplexityRoot.Transaction.Signatures == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Transaction.Signatures(childComplexity), true
 	case "Transaction.success":
 		if e.ComplexityRoot.Transaction.Success == nil {
 			break
@@ -909,7 +1016,11 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputFilterMessageValue,
 		ec.unmarshalInputFilterMsgAddPackage,
 		ec.unmarshalInputFilterMsgCall,
+		ec.unmarshalInputFilterMsgCreateSession,
+		ec.unmarshalInputFilterMsgRevokeAllSessions,
+		ec.unmarshalInputFilterMsgRevokeSession,
 		ec.unmarshalInputFilterMsgRun,
+		ec.unmarshalInputFilterSignature,
 		ec.unmarshalInputFilterStorageDepositEvent,
 		ec.unmarshalInputFilterStorageUnlockEvent,
 		ec.unmarshalInputFilterString,
@@ -924,6 +1035,9 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMemPackageInput,
 		ec.unmarshalInputMsgAddPackageInput,
 		ec.unmarshalInputMsgCallInput,
+		ec.unmarshalInputMsgCreateSessionInput,
+		ec.unmarshalInputMsgRevokeAllSessionsInput,
+		ec.unmarshalInputMsgRevokeSessionInput,
 		ec.unmarshalInputMsgRunInput,
 		ec.unmarshalInputNestedFilterBankMsgSend,
 		ec.unmarshalInputNestedFilterBlockTransaction,
@@ -936,15 +1050,21 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputNestedFilterMessageValue,
 		ec.unmarshalInputNestedFilterMsgAddPackage,
 		ec.unmarshalInputNestedFilterMsgCall,
+		ec.unmarshalInputNestedFilterMsgCreateSession,
+		ec.unmarshalInputNestedFilterMsgRevokeAllSessions,
+		ec.unmarshalInputNestedFilterMsgRevokeSession,
 		ec.unmarshalInputNestedFilterMsgRun,
+		ec.unmarshalInputNestedFilterSignature,
 		ec.unmarshalInputNestedFilterStorageDepositEvent,
 		ec.unmarshalInputNestedFilterStorageUnlockEvent,
 		ec.unmarshalInputNestedFilterTransactionMessage,
 		ec.unmarshalInputNestedFilterTransactionResponse,
 		ec.unmarshalInputNestedFilterTxFee,
 		ec.unmarshalInputNestedFilterUnknownEvent,
+		ec.unmarshalInputSignatureInput,
 		ec.unmarshalInputStorageDepositEventInput,
 		ec.unmarshalInputStorageUnlockEventInput,
+		ec.unmarshalInputTransactionAuthMessageInput,
 		ec.unmarshalInputTransactionBankMessageInput,
 		ec.unmarshalInputTransactionFilter,
 		ec.unmarshalInputTransactionMessageInput,
@@ -1654,6 +1774,18 @@ input FilterMessageValue {
 	filter for MsgRun union type.
 	"""
 	MsgRun: NestedFilterMsgRun
+	"""
+	filter for MsgCreateSession union type.
+	"""
+	MsgCreateSession: NestedFilterMsgCreateSession
+	"""
+	filter for MsgRevokeSession union type.
+	"""
+	MsgRevokeSession: NestedFilterMsgRevokeSession
+	"""
+	filter for MsgRevokeAllSessions union type.
+	"""
+	MsgRevokeAllSessions: NestedFilterMsgRevokeAllSessions
 }
 """
 filter for MsgAddPackage objects
@@ -1734,6 +1866,93 @@ input FilterMsgCall {
 	max_deposit: FilterString
 }
 """
+filter for MsgCreateSession objects
+"""
+input FilterMsgCreateSession {
+	"""
+	logical operator for MsgCreateSession that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [FilterMsgCreateSession]
+	"""
+	logical operator for MsgCreateSession that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [FilterMsgCreateSession]
+	"""
+	logical operator for MsgCreateSession that will reverse conditions.
+	"""
+	_not: FilterMsgCreateSession
+	"""
+	filter for creator field.
+	"""
+	creator: FilterString
+	"""
+	filter for session_key field.
+	"""
+	session_key: FilterString
+	"""
+	filter for expires_at field.
+	"""
+	expires_at: FilterInt
+	"""
+	filter for allow_paths field.
+	"""
+	allow_paths: FilterString
+	"""
+	filter for spend_limit field.
+	"""
+	spend_limit: FilterString
+	"""
+	filter for spend_period field.
+	"""
+	spend_period: FilterInt
+}
+"""
+filter for MsgRevokeAllSessions objects
+"""
+input FilterMsgRevokeAllSessions {
+	"""
+	logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [FilterMsgRevokeAllSessions]
+	"""
+	logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [FilterMsgRevokeAllSessions]
+	"""
+	logical operator for MsgRevokeAllSessions that will reverse conditions.
+	"""
+	_not: FilterMsgRevokeAllSessions
+	"""
+	filter for creator field.
+	"""
+	creator: FilterString
+}
+"""
+filter for MsgRevokeSession objects
+"""
+input FilterMsgRevokeSession {
+	"""
+	logical operator for MsgRevokeSession that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [FilterMsgRevokeSession]
+	"""
+	logical operator for MsgRevokeSession that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [FilterMsgRevokeSession]
+	"""
+	logical operator for MsgRevokeSession that will reverse conditions.
+	"""
+	_not: FilterMsgRevokeSession
+	"""
+	filter for creator field.
+	"""
+	creator: FilterString
+	"""
+	filter for session_key field.
+	"""
+	session_key: FilterString
+}
+"""
 filter for MsgRun objects
 """
 input FilterMsgRun {
@@ -1765,6 +1984,35 @@ input FilterMsgRun {
 	filter for max_deposit field.
 	"""
 	max_deposit: FilterString
+}
+"""
+filter for Signature objects
+"""
+input FilterSignature {
+	"""
+	logical operator for Signature that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [FilterSignature]
+	"""
+	logical operator for Signature that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [FilterSignature]
+	"""
+	logical operator for Signature that will reverse conditions.
+	"""
+	_not: FilterSignature
+	"""
+	filter for pub_key field.
+	"""
+	pub_key: FilterString
+	"""
+	filter for signature field.
+	"""
+	signature: FilterString
+	"""
+	filter for session_addr field.
+	"""
+	session_addr: FilterString
 }
 """
 filter for StorageDepositEvent objects
@@ -1926,6 +2174,10 @@ input FilterTransaction {
 	filter for response field.
 	"""
 	response: NestedFilterTransactionResponse
+	"""
+	filter for signatures field.
+	"""
+	signatures: NestedFilterSignature
 }
 """
 filter for TransactionMessage objects
@@ -2160,15 +2412,17 @@ input MemPackageInput {
 }
 """
 ` + "`" + `MessageRoute` + "`" + ` is route type of the transactional message.
-` + "`" + `MessageRoute` + "`" + ` has the values of vm and bank.
+` + "`" + `MessageRoute` + "`" + ` has the values of vm, bank and auth.
 """
 enum MessageRoute {
 	vm
 	bank
+	auth
 }
 """
 ` + "`" + `MessageType` + "`" + ` is message type of the transaction.
-` + "`" + `MessageType` + "`" + ` has the values ` + "`" + `send` + "`" + `, ` + "`" + `exec` + "`" + `, ` + "`" + `add_package` + "`" + `, and ` + "`" + `run` + "`" + `.
+` + "`" + `MessageType` + "`" + ` has the values ` + "`" + `send` + "`" + `, ` + "`" + `exec` + "`" + `, ` + "`" + `add_package` + "`" + `, ` + "`" + `run` + "`" + `,
+` + "`" + `create_session` + "`" + `, ` + "`" + `revoke_session` + "`" + `, and ` + "`" + `revoke_all_sessions` + "`" + `.
 """
 enum MessageType {
 	"""
@@ -2191,8 +2445,23 @@ enum MessageType {
 	This is a transactional message that executes an arbitrary Gno-coded TX message.
 	"""
 	run
+	"""
+	The route value for this message type is ` + "`" + `auth` + "`" + `, and the value for transactional messages is ` + "`" + `MsgCreateSession` + "`" + `.
+	This is a transactional message that creates a new session key on the creator's account.
+	"""
+	create_session
+	"""
+	The route value for this message type is ` + "`" + `auth` + "`" + `, and the value for transactional messages is ` + "`" + `MsgRevokeSession` + "`" + `.
+	This is a transactional message that revokes a specific session key from the creator's account.
+	"""
+	revoke_session
+	"""
+	The route value for this message type is ` + "`" + `auth` + "`" + `, and the value for transactional messages is ` + "`" + `MsgRevokeAllSessions` + "`" + `.
+	This is a transactional message that revokes all session keys from the creator's account.
+	"""
+	revoke_all_sessions
 }
-union MessageValue = BankMsgSend | MsgCall | MsgAddPackage | MsgRun | UnexpectedMessage
+union MessageValue = BankMsgSend | MsgCall | MsgAddPackage | MsgRun | MsgCreateSession | MsgRevokeSession | MsgRevokeAllSessions | UnexpectedMessage
 """
 ` + "`" + `MsgAddPackage` + "`" + ` is a message with a message router of ` + "`" + `vm` + "`" + ` and a message type of ` + "`" + `add_package` + "`" + `.
 ` + "`" + `MsgAddPackage` + "`" + ` is the package deployment tx message.
@@ -2306,6 +2575,120 @@ input MsgCallInput {
 	ex) ` + "`" + `["", "", "1"]` + "`" + ` <- Empty strings skip the condition.
 	"""
 	args: [String!]
+}
+"""
+` + "`" + `MsgCreateSession` + "`" + ` is a message with a message router of ` + "`" + `auth` + "`" + ` and a message type of ` + "`" + `create_session` + "`" + `.
+` + "`" + `MsgCreateSession` + "`" + ` creates a new session key on the creator's account for delegated signing.
+"""
+type MsgCreateSession {
+	"""
+	the bech32 address of the account owner that creates the session.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	creator: String! @filterable
+	"""
+	the bech32 address derived from the session public key.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	session_key: String! @filterable
+	"""
+	the unix timestamp (in seconds) at which the session expires.
+	` + "`" + `0` + "`" + ` means the session never expires until revoked.
+	"""
+	expires_at: Int! @filterable
+	"""
+	the realm path entries the session is allowed to access.
+	An empty list means the session is unrestricted.
+	"""
+	allow_paths: [String!] @filterable
+	"""
+	the maximum amount of funds the session may spend per period ("<amount><denomination>").
+	An empty value means the session may not spend any funds.
+	ex) ` + "`" + `1000000ugnot` + "`" + `
+	"""
+	spend_limit: String! @filterable
+	"""
+	the spending period in seconds. ` + "`" + `0` + "`" + ` means ` + "`" + `spend_limit` + "`" + ` is a lifetime cap.
+	"""
+	spend_period: Int! @filterable
+}
+"""
+` + "`" + `MsgCreateSessionInput` + "`" + ` represents input parameters required when the message type is ` + "`" + `create_session` + "`" + `.
+"""
+input MsgCreateSessionInput {
+	"""
+	the bech32 address of the account owner that creates the session.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	creator: String
+	"""
+	the bech32 address derived from the session public key.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	session_key: String
+	"""
+	the realm path entries the session is allowed to access.
+	The entries are checked in order and empty strings are excluded from the
+	filtering criteria.
+	ex) ` + "`" + `["", "", "gno.land/r/demo/foo"]` + "`" + ` <- Empty strings skip the condition.
+	"""
+	allow_paths: [String!]
+	"""
+	the maximum amount of funds the session may spend per period.
+	"""
+	spend_limit: AmountInput
+}
+"""
+` + "`" + `MsgRevokeAllSessions` + "`" + ` is a message with a message router of ` + "`" + `auth` + "`" + ` and a message type of ` + "`" + `revoke_all_sessions` + "`" + `.
+` + "`" + `MsgRevokeAllSessions` + "`" + ` revokes all session keys from the creator's account.
+"""
+type MsgRevokeAllSessions {
+	"""
+	the bech32 address of the account owner that revokes all sessions.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	creator: String! @filterable
+}
+"""
+` + "`" + `MsgRevokeAllSessionsInput` + "`" + ` represents input parameters required when the message type is ` + "`" + `revoke_all_sessions` + "`" + `.
+"""
+input MsgRevokeAllSessionsInput {
+	"""
+	the bech32 address of the account owner that revokes all sessions.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	creator: String
+}
+"""
+` + "`" + `MsgRevokeSession` + "`" + ` is a message with a message router of ` + "`" + `auth` + "`" + ` and a message type of ` + "`" + `revoke_session` + "`" + `.
+` + "`" + `MsgRevokeSession` + "`" + ` revokes a specific session key from the creator's account.
+"""
+type MsgRevokeSession {
+	"""
+	the bech32 address of the account owner that revokes the session.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	creator: String! @filterable
+	"""
+	the bech32 address derived from the session public key being revoked.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	session_key: String! @filterable
+}
+"""
+` + "`" + `MsgRevokeSessionInput` + "`" + ` represents input parameters required when the message type is ` + "`" + `revoke_session` + "`" + `.
+"""
+input MsgRevokeSessionInput {
+	"""
+	the bech32 address of the account owner that revokes the session.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	creator: String
+	"""
+	the bech32 address derived from the session public key being revoked.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	session_key: String
 }
 """
 ` + "`" + `MsgRun` + "`" + ` is a message with a message router of ` + "`" + `vm` + "`" + ` and a message type of ` + "`" + `run` + "`" + `.
@@ -2608,6 +2991,18 @@ input NestedFilterMessageValue {
 	filter for MsgRun union type.
 	"""
 	MsgRun: NestedFilterMsgRun
+	"""
+	filter for MsgCreateSession union type.
+	"""
+	MsgCreateSession: NestedFilterMsgCreateSession
+	"""
+	filter for MsgRevokeSession union type.
+	"""
+	MsgRevokeSession: NestedFilterMsgRevokeSession
+	"""
+	filter for MsgRevokeAllSessions union type.
+	"""
+	MsgRevokeAllSessions: NestedFilterMsgRevokeAllSessions
 }
 """
 filter for MsgAddPackage objects
@@ -2688,6 +3083,93 @@ input NestedFilterMsgCall {
 	max_deposit: FilterString
 }
 """
+filter for MsgCreateSession objects
+"""
+input NestedFilterMsgCreateSession {
+	"""
+	logical operator for MsgCreateSession that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [NestedFilterMsgCreateSession]
+	"""
+	logical operator for MsgCreateSession that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [NestedFilterMsgCreateSession]
+	"""
+	logical operator for MsgCreateSession that will reverse conditions.
+	"""
+	_not: NestedFilterMsgCreateSession
+	"""
+	filter for creator field.
+	"""
+	creator: FilterString
+	"""
+	filter for session_key field.
+	"""
+	session_key: FilterString
+	"""
+	filter for expires_at field.
+	"""
+	expires_at: FilterInt
+	"""
+	filter for allow_paths field.
+	"""
+	allow_paths: FilterString
+	"""
+	filter for spend_limit field.
+	"""
+	spend_limit: FilterString
+	"""
+	filter for spend_period field.
+	"""
+	spend_period: FilterInt
+}
+"""
+filter for MsgRevokeAllSessions objects
+"""
+input NestedFilterMsgRevokeAllSessions {
+	"""
+	logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [NestedFilterMsgRevokeAllSessions]
+	"""
+	logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [NestedFilterMsgRevokeAllSessions]
+	"""
+	logical operator for MsgRevokeAllSessions that will reverse conditions.
+	"""
+	_not: NestedFilterMsgRevokeAllSessions
+	"""
+	filter for creator field.
+	"""
+	creator: FilterString
+}
+"""
+filter for MsgRevokeSession objects
+"""
+input NestedFilterMsgRevokeSession {
+	"""
+	logical operator for MsgRevokeSession that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [NestedFilterMsgRevokeSession]
+	"""
+	logical operator for MsgRevokeSession that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [NestedFilterMsgRevokeSession]
+	"""
+	logical operator for MsgRevokeSession that will reverse conditions.
+	"""
+	_not: NestedFilterMsgRevokeSession
+	"""
+	filter for creator field.
+	"""
+	creator: FilterString
+	"""
+	filter for session_key field.
+	"""
+	session_key: FilterString
+}
+"""
 filter for MsgRun objects
 """
 input NestedFilterMsgRun {
@@ -2719,6 +3201,35 @@ input NestedFilterMsgRun {
 	filter for max_deposit field.
 	"""
 	max_deposit: FilterString
+}
+"""
+filter for Signature objects
+"""
+input NestedFilterSignature {
+	"""
+	logical operator for Signature that will combine two or more conditions, returning true if all of them are true.
+	"""
+	_and: [NestedFilterSignature]
+	"""
+	logical operator for Signature that will combine two or more conditions, returning true if at least one of them is true.
+	"""
+	_or: [NestedFilterSignature]
+	"""
+	logical operator for Signature that will reverse conditions.
+	"""
+	_not: NestedFilterSignature
+	"""
+	filter for pub_key field.
+	"""
+	pub_key: FilterString
+	"""
+	filter for signature field.
+	"""
+	signature: FilterString
+	"""
+	filter for session_addr field.
+	"""
+	session_addr: FilterString
 }
 """
 filter for StorageDepositEvent objects
@@ -2937,6 +3448,42 @@ type Query {
 	results and errors are returned.
 	"""
 	getTransactions(where: FilterTransaction!, order: TransactionOrder): [Transaction!]
+}
+"""
+` + "`" + `Signature` + "`" + ` is a wrapped signature that signed a transaction.
+"""
+type Signature {
+	"""
+	the bech32 address of the signer derived from the public key.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	pub_key: String! @filterable
+	"""
+	the signature bytes in base64 encoding.
+	"""
+	signature: String! @filterable
+	"""
+	the bech32 address of the session account used for delegated signing.
+	It is empty for master-key signatures.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	session_addr: String! @filterable
+}
+"""
+Transaction's signature to filter transactions.
+` + "`" + `SignatureInput` + "`" + ` can be configured as a filter with a signature's ` + "`" + `pub_key` + "`" + ` or ` + "`" + `session_addr` + "`" + `.
+"""
+input SignatureInput {
+	"""
+	the bech32 address of the signer derived from the public key.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	pub_key: String
+	"""
+	the bech32 address of the session account used for delegated signing.
+	ex) ` + "`" + `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5` + "`" + `
+	"""
+	session_addr: String
 }
 """
 ` + "`" + `StorageDepositEvent` + "`" + ` is emitted when a storage deposit fee is locked.
@@ -3169,6 +3716,30 @@ type Transaction {
 	It has ` + "`" + `log` + "`" + `, ` + "`" + `info` + "`" + `, ` + "`" + `error` + "`" + `, and ` + "`" + `data` + "`" + `.
 	"""
 	response: TransactionResponse! @filterable
+	"""
+	` + "`" + `signatures` + "`" + ` are the signatures that signed the transaction.
+	Each signature includes the signer's public key, the signature bytes, and
+	an optional ` + "`" + `session_addr` + "`" + ` identifying the session account used for
+	delegated signing (empty for master-key signatures).
+	"""
+	signatures: [Signature!] @filterable
+}
+"""
+` + "`" + `TransactionAuthMessageInput` + "`" + ` represents input parameters required when the message router is ` + "`" + `auth` + "`" + `.
+"""
+input TransactionAuthMessageInput {
+	"""
+	` + "`" + `MsgCreateSessionInput` + "`" + ` represents input parameters required when the message type is ` + "`" + `create_session` + "`" + `.
+	"""
+	create_session: MsgCreateSessionInput
+	"""
+	` + "`" + `MsgRevokeSessionInput` + "`" + ` represents input parameters required when the message type is ` + "`" + `revoke_session` + "`" + `.
+	"""
+	revoke_session: MsgRevokeSessionInput
+	"""
+	` + "`" + `MsgRevokeAllSessionsInput` + "`" + ` represents input parameters required when the message type is ` + "`" + `revoke_all_sessions` + "`" + `.
+	"""
+	revoke_all_sessions: MsgRevokeAllSessionsInput
 }
 """
 ` + "`" + `TransactionBankMessageInput` + "`" + ` represents input parameters required when the message router is ` + "`" + `bank` + "`" + `.
@@ -3244,6 +3815,13 @@ input TransactionFilter {
 	ex) ` + "`" + `events[0] || events[1] || events[2]` + "`" + `
 	"""
 	events: [EventInput!]
+	"""
+	` + "`" + `signatures` + "`" + ` are the signatures that signed the transaction.
+	` + "`" + `signatures` + "`" + ` can be filtered with a specific signer, signature, or session address.
+	` + "`" + `signatures` + "`" + ` is entered as an array and works exclusively.
+	ex) ` + "`" + `signatures[0] || signatures[1] || signatures[2]` + "`" + `
+	"""
+	signatures: [SignatureInput!]
 }
 type TransactionMessage {
 	"""
@@ -3258,7 +3836,8 @@ type TransactionMessage {
 	route: String! @filterable
 	"""
 	MessageValue is the content of the transaction.
-	` + "`" + `value` + "`" + ` can be of type ` + "`" + `BankMsgSend` + "`" + `, ` + "`" + `MsgCall` + "`" + `, ` + "`" + `MsgAddPackage` + "`" + `, ` + "`" + `MsgRun` + "`" + `, ` + "`" + `UnexpectedMessage` + "`" + `.
+	` + "`" + `value` + "`" + ` can be of type ` + "`" + `BankMsgSend` + "`" + `, ` + "`" + `MsgCall` + "`" + `, ` + "`" + `MsgAddPackage` + "`" + `, ` + "`" + `MsgRun` + "`" + `,
+	` + "`" + `MsgCreateSession` + "`" + `, ` + "`" + `MsgRevokeSession` + "`" + `, ` + "`" + `MsgRevokeAllSessions` + "`" + `, ` + "`" + `UnexpectedMessage` + "`" + `.
 	"""
 	value: MessageValue! @filterable
 }
@@ -3285,6 +3864,10 @@ input TransactionMessageInput {
 	` + "`" + `TransactionVmMessageInput` + "`" + ` represents input parameters required when the message router is ` + "`" + `vm` + "`" + `.
 	"""
 	vm_param: TransactionVmMessageInput
+	"""
+	` + "`" + `TransactionAuthMessageInput` + "`" + ` represents input parameters required when the message router is ` + "`" + `auth` + "`" + `.
+	"""
+	auth_param: TransactionAuthMessageInput
 }
 input TransactionOrder {
 	heightAndIndex: Order!
@@ -5554,6 +6137,384 @@ func (ec *executionContext) fieldContext_MsgCall_max_deposit(_ context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _MsgCreateSession_creator(ctx context.Context, field graphql.CollectedField, obj *model.MsgCreateSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgCreateSession_creator,
+		func(ctx context.Context) (any, error) {
+			return obj.Creator, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgCreateSession_creator(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgCreateSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgCreateSession_session_key(ctx context.Context, field graphql.CollectedField, obj *model.MsgCreateSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgCreateSession_session_key,
+		func(ctx context.Context) (any, error) {
+			return obj.SessionKey, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgCreateSession_session_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgCreateSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgCreateSession_expires_at(ctx context.Context, field graphql.CollectedField, obj *model.MsgCreateSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgCreateSession_expires_at,
+		func(ctx context.Context) (any, error) {
+			return obj.ExpiresAt, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal int
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgCreateSession_expires_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgCreateSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgCreateSession_allow_paths(ctx context.Context, field graphql.CollectedField, obj *model.MsgCreateSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgCreateSession_allow_paths,
+		func(ctx context.Context) (any, error) {
+			return obj.AllowPaths, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal []string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgCreateSession_allow_paths(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgCreateSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgCreateSession_spend_limit(ctx context.Context, field graphql.CollectedField, obj *model.MsgCreateSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgCreateSession_spend_limit,
+		func(ctx context.Context) (any, error) {
+			return obj.SpendLimit, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgCreateSession_spend_limit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgCreateSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgCreateSession_spend_period(ctx context.Context, field graphql.CollectedField, obj *model.MsgCreateSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgCreateSession_spend_period,
+		func(ctx context.Context) (any, error) {
+			return obj.SpendPeriod, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal int
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgCreateSession_spend_period(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgCreateSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgRevokeAllSessions_creator(ctx context.Context, field graphql.CollectedField, obj *model.MsgRevokeAllSessions) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgRevokeAllSessions_creator,
+		func(ctx context.Context) (any, error) {
+			return obj.Creator, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgRevokeAllSessions_creator(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgRevokeAllSessions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgRevokeSession_creator(ctx context.Context, field graphql.CollectedField, obj *model.MsgRevokeSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgRevokeSession_creator,
+		func(ctx context.Context) (any, error) {
+			return obj.Creator, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgRevokeSession_creator(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgRevokeSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _MsgRevokeSession_session_key(ctx context.Context, field graphql.CollectedField, obj *model.MsgRevokeSession) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_MsgRevokeSession_session_key,
+		func(ctx context.Context) (any, error) {
+			return obj.SessionKey, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_MsgRevokeSession_session_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MsgRevokeSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _MsgRun_caller(ctx context.Context, field graphql.CollectedField, obj *model.MsgRun) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -5777,6 +6738,8 @@ func (ec *executionContext) fieldContext_Query_transactions(ctx context.Context,
 				return ec.fieldContext_Transaction_memo(ctx, field)
 			case "response":
 				return ec.fieldContext_Transaction_response(ctx, field)
+			case "signatures":
+				return ec.fieldContext_Transaction_signatures(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Transaction", field.Name)
 		},
@@ -6078,6 +7041,8 @@ func (ec *executionContext) fieldContext_Query_getTransactions(ctx context.Conte
 				return ec.fieldContext_Transaction_memo(ctx, field)
 			case "response":
 				return ec.fieldContext_Transaction_response(ctx, field)
+			case "signatures":
+				return ec.fieldContext_Transaction_signatures(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Transaction", field.Name)
 		},
@@ -6199,6 +7164,132 @@ func (ec *executionContext) fieldContext_Query___schema(_ context.Context, field
 				return ec.fieldContext___Schema_directives(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type __Schema", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Signature_pub_key(ctx context.Context, field graphql.CollectedField, obj *model.Signature) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Signature_pub_key,
+		func(ctx context.Context) (any, error) {
+			return obj.PubKey, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Signature_pub_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Signature",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Signature_signature(ctx context.Context, field graphql.CollectedField, obj *model.Signature) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Signature_signature,
+		func(ctx context.Context) (any, error) {
+			return obj.Signature, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Signature_signature(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Signature",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Signature_session_addr(ctx context.Context, field graphql.CollectedField, obj *model.Signature) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Signature_session_addr,
+		func(ctx context.Context) (any, error) {
+			return obj.SessionAddr, nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Signature_session_addr(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Signature",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6599,6 +7690,8 @@ func (ec *executionContext) fieldContext_Subscription_transactions(ctx context.C
 				return ec.fieldContext_Transaction_memo(ctx, field)
 			case "response":
 				return ec.fieldContext_Transaction_response(ctx, field)
+			case "signatures":
+				return ec.fieldContext_Transaction_signatures(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Transaction", field.Name)
 		},
@@ -6741,6 +7834,8 @@ func (ec *executionContext) fieldContext_Subscription_getTransactions(ctx contex
 				return ec.fieldContext_Transaction_memo(ctx, field)
 			case "response":
 				return ec.fieldContext_Transaction_response(ctx, field)
+			case "signatures":
+				return ec.fieldContext_Transaction_signatures(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Transaction", field.Name)
 		},
@@ -7461,6 +8556,56 @@ func (ec *executionContext) fieldContext_Transaction_response(_ context.Context,
 				return ec.fieldContext_TransactionResponse_events(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TransactionResponse", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Transaction_signatures(ctx context.Context, field graphql.CollectedField, obj *model.Transaction) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Transaction_signatures,
+		func(ctx context.Context) (any, error) {
+			return obj.Signatures(), nil
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.Directives.Filterable == nil {
+					var zeroVal []*model.Signature
+					return zeroVal, errors.New("directive filterable is not implemented")
+				}
+				return ec.Directives.Filterable(ctx, obj, directive0, nil)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalOSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignatureᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Transaction_signatures(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Transaction",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "pub_key":
+				return ec.fieldContext_Signature_pub_key(ctx, field)
+			case "signature":
+				return ec.fieldContext_Signature_signature(ctx, field)
+			case "session_addr":
+				return ec.fieldContext_Signature_session_addr(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Signature", field.Name)
 		},
 	}
 	return fc, nil
@@ -10464,7 +11609,7 @@ func (ec *executionContext) unmarshalInputFilterMessageValue(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"_and", "_or", "_not", "BankMsgSend", "MsgCall", "MsgAddPackage", "MsgRun"}
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "BankMsgSend", "MsgCall", "MsgAddPackage", "MsgRun", "MsgCreateSession", "MsgRevokeSession", "MsgRevokeAllSessions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -10520,6 +11665,27 @@ func (ec *executionContext) unmarshalInputFilterMessageValue(ctx context.Context
 				return it, err
 			}
 			it.MsgRun = data
+		case "MsgCreateSession":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("MsgCreateSession"))
+			data, err := ec.unmarshalONestedFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MsgCreateSession = data
+		case "MsgRevokeSession":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("MsgRevokeSession"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MsgRevokeSession = data
+		case "MsgRevokeAllSessions":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("MsgRevokeAllSessions"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MsgRevokeAllSessions = data
 		}
 	}
 	return it, nil
@@ -10690,6 +11856,201 @@ func (ec *executionContext) unmarshalInputFilterMsgCall(ctx context.Context, obj
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputFilterMsgCreateSession(ctx context.Context, obj any) (model.FilterMsgCreateSession, error) {
+	var it model.FilterMsgCreateSession
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "creator", "session_key", "expires_at", "allow_paths", "spend_limit", "spend_period"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalOFilterMsgCreateSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalOFilterMsgCreateSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalOFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		case "session_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_key"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionKey = data
+		case "expires_at":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expires_at"))
+			data, err := ec.unmarshalOFilterInt2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterInt(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExpiresAt = data
+		case "allow_paths":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allow_paths"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowPaths = data
+		case "spend_limit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("spend_limit"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpendLimit = data
+		case "spend_period":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("spend_period"))
+			data, err := ec.unmarshalOFilterInt2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterInt(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpendPeriod = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputFilterMsgRevokeAllSessions(ctx context.Context, obj any) (model.FilterMsgRevokeAllSessions, error) {
+	var it model.FilterMsgRevokeAllSessions
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "creator"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalOFilterMsgRevokeAllSessions2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalOFilterMsgRevokeAllSessions2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalOFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputFilterMsgRevokeSession(ctx context.Context, obj any) (model.FilterMsgRevokeSession, error) {
+	var it model.FilterMsgRevokeSession
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "creator", "session_key"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalOFilterMsgRevokeSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalOFilterMsgRevokeSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalOFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		case "session_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_key"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionKey = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputFilterMsgRun(ctx context.Context, obj any) (model.FilterMsgRun, error) {
 	var it model.FilterMsgRun
 	if obj == nil {
@@ -10757,6 +12118,71 @@ func (ec *executionContext) unmarshalInputFilterMsgRun(ctx context.Context, obj 
 				return it, err
 			}
 			it.MaxDeposit = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputFilterSignature(ctx context.Context, obj any) (model.FilterSignature, error) {
+	var it model.FilterSignature
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "pub_key", "signature", "session_addr"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalOFilterSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterSignature(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalOFilterSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterSignature(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalOFilterSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterSignature(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "pub_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pub_key"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PubKey = data
+		case "signature":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("signature"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Signature = data
+		case "session_addr":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_addr"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionAddr = data
 		}
 	}
 	return it, nil
@@ -11012,7 +12438,7 @@ func (ec *executionContext) unmarshalInputFilterTransaction(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"_and", "_or", "_not", "index", "hash", "success", "block_height", "gas_wanted", "gas_used", "gas_fee", "messages", "memo", "response"}
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "index", "hash", "success", "block_height", "gas_wanted", "gas_used", "gas_fee", "messages", "memo", "response", "signatures"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -11110,6 +12536,13 @@ func (ec *executionContext) unmarshalInputFilterTransaction(ctx context.Context,
 				return it, err
 			}
 			it.Response = data
+		case "signatures":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("signatures"))
+			data, err := ec.unmarshalONestedFilterSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterSignature(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Signatures = data
 		}
 	}
 	return it, nil
@@ -11590,6 +13023,124 @@ func (ec *executionContext) unmarshalInputMsgCallInput(ctx context.Context, obj 
 				return it, err
 			}
 			it.Args = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputMsgCreateSessionInput(ctx context.Context, obj any) (model.MsgCreateSessionInput, error) {
+	var it model.MsgCreateSessionInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"creator", "session_key", "allow_paths", "spend_limit"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		case "session_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_key"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionKey = data
+		case "allow_paths":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allow_paths"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowPaths = data
+		case "spend_limit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("spend_limit"))
+			data, err := ec.unmarshalOAmountInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐAmountInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpendLimit = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputMsgRevokeAllSessionsInput(ctx context.Context, obj any) (model.MsgRevokeAllSessionsInput, error) {
+	var it model.MsgRevokeAllSessionsInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"creator"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputMsgRevokeSessionInput(ctx context.Context, obj any) (model.MsgRevokeSessionInput, error) {
+	var it model.MsgRevokeSessionInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"creator", "session_key"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		case "session_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_key"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionKey = data
 		}
 	}
 	return it, nil
@@ -12156,7 +13707,7 @@ func (ec *executionContext) unmarshalInputNestedFilterMessageValue(ctx context.C
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"_and", "_or", "_not", "BankMsgSend", "MsgCall", "MsgAddPackage", "MsgRun"}
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "BankMsgSend", "MsgCall", "MsgAddPackage", "MsgRun", "MsgCreateSession", "MsgRevokeSession", "MsgRevokeAllSessions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -12212,6 +13763,27 @@ func (ec *executionContext) unmarshalInputNestedFilterMessageValue(ctx context.C
 				return it, err
 			}
 			it.MsgRun = data
+		case "MsgCreateSession":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("MsgCreateSession"))
+			data, err := ec.unmarshalONestedFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MsgCreateSession = data
+		case "MsgRevokeSession":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("MsgRevokeSession"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MsgRevokeSession = data
+		case "MsgRevokeAllSessions":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("MsgRevokeAllSessions"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MsgRevokeAllSessions = data
 		}
 	}
 	return it, nil
@@ -12382,6 +13954,201 @@ func (ec *executionContext) unmarshalInputNestedFilterMsgCall(ctx context.Contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputNestedFilterMsgCreateSession(ctx context.Context, obj any) (model.NestedFilterMsgCreateSession, error) {
+	var it model.NestedFilterMsgCreateSession
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "creator", "session_key", "expires_at", "allow_paths", "spend_limit", "spend_period"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalONestedFilterMsgCreateSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalONestedFilterMsgCreateSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalONestedFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		case "session_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_key"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionKey = data
+		case "expires_at":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expires_at"))
+			data, err := ec.unmarshalOFilterInt2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterInt(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExpiresAt = data
+		case "allow_paths":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allow_paths"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowPaths = data
+		case "spend_limit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("spend_limit"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpendLimit = data
+		case "spend_period":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("spend_period"))
+			data, err := ec.unmarshalOFilterInt2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterInt(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SpendPeriod = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputNestedFilterMsgRevokeAllSessions(ctx context.Context, obj any) (model.NestedFilterMsgRevokeAllSessions, error) {
+	var it model.NestedFilterMsgRevokeAllSessions
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "creator"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeAllSessions2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeAllSessions2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputNestedFilterMsgRevokeSession(ctx context.Context, obj any) (model.NestedFilterMsgRevokeSession, error) {
+	var it model.NestedFilterMsgRevokeSession
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "creator", "session_key"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalONestedFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "creator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("creator"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Creator = data
+		case "session_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_key"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionKey = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputNestedFilterMsgRun(ctx context.Context, obj any) (model.NestedFilterMsgRun, error) {
 	var it model.NestedFilterMsgRun
 	if obj == nil {
@@ -12449,6 +14216,71 @@ func (ec *executionContext) unmarshalInputNestedFilterMsgRun(ctx context.Context
 				return it, err
 			}
 			it.MaxDeposit = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputNestedFilterSignature(ctx context.Context, obj any) (model.NestedFilterSignature, error) {
+	var it model.NestedFilterSignature
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"_and", "_or", "_not", "pub_key", "signature", "session_addr"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "_and":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_and"))
+			data, err := ec.unmarshalONestedFilterSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterSignature(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.And = data
+		case "_or":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_or"))
+			data, err := ec.unmarshalONestedFilterSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterSignature(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Or = data
+		case "_not":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("_not"))
+			data, err := ec.unmarshalONestedFilterSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterSignature(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Not = data
+		case "pub_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pub_key"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PubKey = data
+		case "signature":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("signature"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Signature = data
+		case "session_addr":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_addr"))
+			data, err := ec.unmarshalOFilterString2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterString(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionAddr = data
 		}
 	}
 	return it, nil
@@ -12851,6 +14683,43 @@ func (ec *executionContext) unmarshalInputNestedFilterUnknownEvent(ctx context.C
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputSignatureInput(ctx context.Context, obj any) (model.SignatureInput, error) {
+	var it model.SignatureInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"pub_key", "session_addr"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "pub_key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pub_key"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PubKey = data
+		case "session_addr":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_addr"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionAddr = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputStorageDepositEventInput(ctx context.Context, obj any) (model.StorageDepositEventInput, error) {
 	var it model.StorageDepositEventInput
 	if obj == nil {
@@ -12953,6 +14822,50 @@ func (ec *executionContext) unmarshalInputStorageUnlockEventInput(ctx context.Co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputTransactionAuthMessageInput(ctx context.Context, obj any) (model.TransactionAuthMessageInput, error) {
+	var it model.TransactionAuthMessageInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"create_session", "revoke_session", "revoke_all_sessions"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "create_session":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("create_session"))
+			data, err := ec.unmarshalOMsgCreateSessionInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐMsgCreateSessionInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CreateSession = data
+		case "revoke_session":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("revoke_session"))
+			data, err := ec.unmarshalOMsgRevokeSessionInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐMsgRevokeSessionInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RevokeSession = data
+		case "revoke_all_sessions":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("revoke_all_sessions"))
+			data, err := ec.unmarshalOMsgRevokeAllSessionsInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐMsgRevokeAllSessionsInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RevokeAllSessions = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputTransactionBankMessageInput(ctx context.Context, obj any) (model.TransactionBankMessageInput, error) {
 	var it model.TransactionBankMessageInput
 	if obj == nil {
@@ -12994,7 +14907,7 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"from_block_height", "to_block_height", "from_index", "to_index", "from_gas_wanted", "to_gas_wanted", "from_gas_used", "to_gas_used", "hash", "message", "memo", "success", "events"}
+	fieldsInOrder := [...]string{"from_block_height", "to_block_height", "from_index", "to_index", "from_gas_wanted", "to_gas_wanted", "from_gas_used", "to_gas_used", "hash", "message", "memo", "success", "events", "signatures"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -13092,6 +15005,13 @@ func (ec *executionContext) unmarshalInputTransactionFilter(ctx context.Context,
 				return it, err
 			}
 			it.Events = data
+		case "signatures":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("signatures"))
+			data, err := ec.unmarshalOSignatureInput2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignatureInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Signatures = data
 		}
 	}
 	return it, nil
@@ -13108,7 +15028,7 @@ func (ec *executionContext) unmarshalInputTransactionMessageInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type_url", "route", "bank_param", "vm_param"}
+	fieldsInOrder := [...]string{"type_url", "route", "bank_param", "vm_param", "auth_param"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -13143,6 +15063,13 @@ func (ec *executionContext) unmarshalInputTransactionMessageInput(ctx context.Co
 				return it, err
 			}
 			it.VMParam = data
+		case "auth_param":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auth_param"))
+			data, err := ec.unmarshalOTransactionAuthMessageInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionAuthMessageInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuthParam = data
 		}
 	}
 	return it, nil
@@ -13285,6 +15212,27 @@ func (ec *executionContext) _MessageValue(ctx context.Context, sel ast.Selection
 			return graphql.Null
 		}
 		return ec._MsgRun(ctx, sel, obj)
+	case model.MsgRevokeSession:
+		return ec._MsgRevokeSession(ctx, sel, &obj)
+	case *model.MsgRevokeSession:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MsgRevokeSession(ctx, sel, obj)
+	case model.MsgRevokeAllSessions:
+		return ec._MsgRevokeAllSessions(ctx, sel, &obj)
+	case *model.MsgRevokeAllSessions:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MsgRevokeAllSessions(ctx, sel, obj)
+	case model.MsgCreateSession:
+		return ec._MsgCreateSession(ctx, sel, &obj)
+	case *model.MsgCreateSession:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MsgCreateSession(ctx, sel, obj)
 	case model.MsgCall:
 		return ec._MsgCall(ctx, sel, &obj)
 	case *model.MsgCall:
@@ -13885,6 +15833,150 @@ func (ec *executionContext) _MsgCall(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var msgCreateSessionImplementors = []string{"MsgCreateSession", "MessageValue"}
+
+func (ec *executionContext) _MsgCreateSession(ctx context.Context, sel ast.SelectionSet, obj *model.MsgCreateSession) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, msgCreateSessionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("MsgCreateSession")
+		case "creator":
+			out.Values[i] = ec._MsgCreateSession_creator(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "session_key":
+			out.Values[i] = ec._MsgCreateSession_session_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "expires_at":
+			out.Values[i] = ec._MsgCreateSession_expires_at(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "allow_paths":
+			out.Values[i] = ec._MsgCreateSession_allow_paths(ctx, field, obj)
+		case "spend_limit":
+			out.Values[i] = ec._MsgCreateSession_spend_limit(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "spend_period":
+			out.Values[i] = ec._MsgCreateSession_spend_period(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var msgRevokeAllSessionsImplementors = []string{"MsgRevokeAllSessions", "MessageValue"}
+
+func (ec *executionContext) _MsgRevokeAllSessions(ctx context.Context, sel ast.SelectionSet, obj *model.MsgRevokeAllSessions) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, msgRevokeAllSessionsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("MsgRevokeAllSessions")
+		case "creator":
+			out.Values[i] = ec._MsgRevokeAllSessions_creator(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var msgRevokeSessionImplementors = []string{"MsgRevokeSession", "MessageValue"}
+
+func (ec *executionContext) _MsgRevokeSession(ctx context.Context, sel ast.SelectionSet, obj *model.MsgRevokeSession) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, msgRevokeSessionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("MsgRevokeSession")
+		case "creator":
+			out.Values[i] = ec._MsgRevokeSession_creator(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "session_key":
+			out.Values[i] = ec._MsgRevokeSession_session_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var msgRunImplementors = []string{"MsgRun", "MessageValue"}
 
 func (ec *executionContext) _MsgRun(ctx context.Context, sel ast.SelectionSet, obj *model.MsgRun) graphql.Marshaler {
@@ -14086,6 +16178,55 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___schema(ctx, field)
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var signatureImplementors = []string{"Signature"}
+
+func (ec *executionContext) _Signature(ctx context.Context, sel ast.SelectionSet, obj *model.Signature) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, signatureImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Signature")
+		case "pub_key":
+			out.Values[i] = ec._Signature_pub_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "signature":
+			out.Values[i] = ec._Signature_signature(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "session_addr":
+			out.Values[i] = ec._Signature_session_addr(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -14365,6 +16506,8 @@ func (ec *executionContext) _Transaction(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "signatures":
+			out.Values[i] = ec._Transaction_signatures(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -15117,6 +17260,21 @@ func (ec *executionContext) marshalNOrder2githubᚗcomᚋgnolangᚋtxᚑindexer�
 	return v
 }
 
+func (ec *executionContext) marshalNSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignature(ctx context.Context, sel ast.SelectionSet, v *model.Signature) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Signature(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNSignatureInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignatureInput(ctx context.Context, v any) (*model.SignatureInput, error) {
+	res, err := ec.unmarshalInputSignatureInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {
 	res, err := graphql.UnmarshalString(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -15837,6 +17995,84 @@ func (ec *executionContext) unmarshalOFilterMsgCall2ᚖgithubᚗcomᚋgnolangᚋ
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalOFilterMsgCreateSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgCreateSession(ctx context.Context, v any) ([]*model.FilterMsgCreateSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.FilterMsgCreateSession, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgCreateSession(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgCreateSession(ctx context.Context, v any) (*model.FilterMsgCreateSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputFilterMsgCreateSession(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOFilterMsgRevokeAllSessions2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeAllSessions(ctx context.Context, v any) ([]*model.FilterMsgRevokeAllSessions, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.FilterMsgRevokeAllSessions, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeAllSessions(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeAllSessions(ctx context.Context, v any) (*model.FilterMsgRevokeAllSessions, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputFilterMsgRevokeAllSessions(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOFilterMsgRevokeSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeSession(ctx context.Context, v any) ([]*model.FilterMsgRevokeSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.FilterMsgRevokeSession, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeSession(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRevokeSession(ctx context.Context, v any) (*model.FilterMsgRevokeSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputFilterMsgRevokeSession(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalOFilterMsgRun2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterMsgRun(ctx context.Context, v any) ([]*model.FilterMsgRun, error) {
 	if v == nil {
 		return nil, nil
@@ -15860,6 +18096,32 @@ func (ec *executionContext) unmarshalOFilterMsgRun2ᚖgithubᚗcomᚋgnolangᚋt
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputFilterMsgRun(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOFilterSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterSignature(ctx context.Context, v any) ([]*model.FilterSignature, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.FilterSignature, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOFilterSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterSignature(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalOFilterSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐFilterSignature(ctx context.Context, v any) (*model.FilterSignature, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputFilterSignature(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -16244,6 +18506,30 @@ func (ec *executionContext) unmarshalOMsgCallInput2ᚖgithubᚗcomᚋgnolangᚋt
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalOMsgCreateSessionInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐMsgCreateSessionInput(ctx context.Context, v any) (*model.MsgCreateSessionInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputMsgCreateSessionInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOMsgRevokeAllSessionsInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐMsgRevokeAllSessionsInput(ctx context.Context, v any) (*model.MsgRevokeAllSessionsInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputMsgRevokeAllSessionsInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOMsgRevokeSessionInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐMsgRevokeSessionInput(ctx context.Context, v any) (*model.MsgRevokeSessionInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputMsgRevokeSessionInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalOMsgRunInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐMsgRunInput(ctx context.Context, v any) (*model.MsgRunInput, error) {
 	if v == nil {
 		return nil, nil
@@ -16538,6 +18824,84 @@ func (ec *executionContext) unmarshalONestedFilterMsgCall2ᚖgithubᚗcomᚋgnol
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalONestedFilterMsgCreateSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx context.Context, v any) ([]*model.NestedFilterMsgCreateSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.NestedFilterMsgCreateSession, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalONestedFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalONestedFilterMsgCreateSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgCreateSession(ctx context.Context, v any) (*model.NestedFilterMsgCreateSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputNestedFilterMsgCreateSession(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalONestedFilterMsgRevokeAllSessions2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx context.Context, v any) ([]*model.NestedFilterMsgRevokeAllSessions, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.NestedFilterMsgRevokeAllSessions, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalONestedFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalONestedFilterMsgRevokeAllSessions2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeAllSessions(ctx context.Context, v any) (*model.NestedFilterMsgRevokeAllSessions, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputNestedFilterMsgRevokeAllSessions(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalONestedFilterMsgRevokeSession2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx context.Context, v any) ([]*model.NestedFilterMsgRevokeSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.NestedFilterMsgRevokeSession, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalONestedFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalONestedFilterMsgRevokeSession2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRevokeSession(ctx context.Context, v any) (*model.NestedFilterMsgRevokeSession, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputNestedFilterMsgRevokeSession(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalONestedFilterMsgRun2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterMsgRun(ctx context.Context, v any) ([]*model.NestedFilterMsgRun, error) {
 	if v == nil {
 		return nil, nil
@@ -16561,6 +18925,32 @@ func (ec *executionContext) unmarshalONestedFilterMsgRun2ᚖgithubᚗcomᚋgnola
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputNestedFilterMsgRun(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalONestedFilterSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterSignature(ctx context.Context, v any) ([]*model.NestedFilterSignature, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.NestedFilterSignature, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalONestedFilterSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterSignature(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalONestedFilterSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐNestedFilterSignature(ctx context.Context, v any) (*model.NestedFilterSignature, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputNestedFilterSignature(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -16720,6 +19110,43 @@ func (ec *executionContext) unmarshalONestedFilterUnknownEvent2ᚖgithubᚗcom�
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalOSignature2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignatureᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Signature) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNSignature2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignature(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalOSignatureInput2ᚕᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignatureInputᚄ(ctx context.Context, v any) ([]*model.SignatureInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.SignatureInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNSignatureInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐSignatureInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func (ec *executionContext) unmarshalOStorageDepositEventInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐStorageDepositEventInput(ctx context.Context, v any) (*model.StorageDepositEventInput, error) {
 	if v == nil {
 		return nil, nil
@@ -16825,6 +19252,14 @@ func (ec *executionContext) marshalOTransaction2ᚕᚖgithubᚗcomᚋgnolangᚋt
 	}
 
 	return ret
+}
+
+func (ec *executionContext) unmarshalOTransactionAuthMessageInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionAuthMessageInput(ctx context.Context, v any) (*model.TransactionAuthMessageInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTransactionAuthMessageInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOTransactionBankMessageInput2ᚖgithubᚗcomᚋgnolangᚋtxᚑindexerᚋserveᚋgraphᚋmodelᚐTransactionBankMessageInput(ctx context.Context, v any) (*model.TransactionBankMessageInput, error) {

--- a/serve/graph/model/filter_methods_gen.go
+++ b/serve/graph/model/filter_methods_gen.go
@@ -336,6 +336,58 @@ func (f *NestedFilterStorageDepositEvent) Eval(obj *StorageDepositEvent) bool {
 	return true
 }
 
+func (f *NestedFilterSignature) Eval(obj *Signature) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle Signature field
+	toEvalSignature := obj.Signature
+	if f.Signature != nil && !f.Signature.Eval(&toEvalSignature) {
+		return false
+	}
+
+	// Handle SessionAddr field
+	toEvalSessionAddr := obj.SessionAddr
+	if f.SessionAddr != nil && !f.SessionAddr.Eval(&toEvalSessionAddr) {
+		return false
+	}
+
+	// Handle PubKey field
+	toEvalPubKey := obj.PubKey
+	if f.PubKey != nil && !f.PubKey.Eval(&toEvalPubKey) {
+		return false
+	}
+
+	return true
+}
+
 func (f *NestedFilterMsgRun) Eval(obj *MsgRun) bool {
 	// Evaluate logical operators first
 	if len(f.And) > 0 {
@@ -389,6 +441,171 @@ func (f *NestedFilterMsgRun) Eval(obj *MsgRun) bool {
 	toEvalCaller := obj.Caller
 	if f.Caller != nil && !f.Caller.Eval(&toEvalCaller) {
 		return false
+	}
+
+	return true
+}
+
+func (f *NestedFilterMsgRevokeSession) Eval(obj *MsgRevokeSession) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle SessionKey field
+	toEvalSessionKey := obj.SessionKey
+	if f.SessionKey != nil && !f.SessionKey.Eval(&toEvalSessionKey) {
+		return false
+	}
+
+	// Handle Creator field
+	toEvalCreator := obj.Creator
+	if f.Creator != nil && !f.Creator.Eval(&toEvalCreator) {
+		return false
+	}
+
+	return true
+}
+
+func (f *NestedFilterMsgRevokeAllSessions) Eval(obj *MsgRevokeAllSessions) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle Creator field
+	toEvalCreator := obj.Creator
+	if f.Creator != nil && !f.Creator.Eval(&toEvalCreator) {
+		return false
+	}
+
+	return true
+}
+
+func (f *NestedFilterMsgCreateSession) Eval(obj *MsgCreateSession) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle SpendPeriod field
+	toEvalSpendPeriod := toIntPtr(obj.SpendPeriod)
+	if f.SpendPeriod != nil && !f.SpendPeriod.Eval(toEvalSpendPeriod) {
+		return false
+	}
+
+	// Handle SpendLimit field
+	toEvalSpendLimit := obj.SpendLimit
+	if f.SpendLimit != nil && !f.SpendLimit.Eval(&toEvalSpendLimit) {
+		return false
+	}
+
+	// Handle SessionKey field
+	toEvalSessionKey := obj.SessionKey
+	if f.SessionKey != nil && !f.SessionKey.Eval(&toEvalSessionKey) {
+		return false
+	}
+
+	// Handle ExpiresAt field
+	toEvalExpiresAt := toIntPtr(obj.ExpiresAt)
+	if f.ExpiresAt != nil && !f.ExpiresAt.Eval(toEvalExpiresAt) {
+		return false
+	}
+
+	// Handle Creator field
+	toEvalCreator := obj.Creator
+	if f.Creator != nil && !f.Creator.Eval(&toEvalCreator) {
+		return false
+	}
+
+	// Handle AllowPaths slice
+	if f.AllowPaths != nil {
+		elemMatchAllowPaths := false
+		for _, elem := range obj.AllowPaths {
+			if f.AllowPaths.Eval(&elem) {
+				elemMatchAllowPaths = true
+			}
+		}
+
+		if !elemMatchAllowPaths {
+			return false
+		}
+
 	}
 
 	return true
@@ -569,7 +786,7 @@ func (f *NestedFilterMessageValue) Eval(obj *MessageValue) bool {
 	// Handle union objects depending of the type
 
 	// Check if any filters are specified
-	filtersSpecified := f.BankMsgSend != nil || f.MsgCall != nil || f.MsgAddPackage != nil || f.MsgRun != nil || false
+	filtersSpecified := f.BankMsgSend != nil || f.MsgCall != nil || f.MsgAddPackage != nil || f.MsgRun != nil || f.MsgCreateSession != nil || f.MsgRevokeSession != nil || f.MsgRevokeAllSessions != nil || false
 
 	// If no filters are specified for any types, accept all objects
 	if !filtersSpecified {
@@ -628,6 +845,45 @@ func (f *NestedFilterMessageValue) Eval(obj *MessageValue) bool {
 	if uObj, ok := tobj.(*MsgRun); ok {
 		matchedType = true
 		if f.MsgRun != nil && f.MsgRun.Eval(uObj) {
+			return true
+		}
+	}
+
+	if uObj, ok := tobj.(MsgCreateSession); ok {
+		matchedType = true
+		if f.MsgCreateSession != nil && f.MsgCreateSession.Eval(&uObj) {
+			return true
+		}
+	}
+	if uObj, ok := tobj.(*MsgCreateSession); ok {
+		matchedType = true
+		if f.MsgCreateSession != nil && f.MsgCreateSession.Eval(uObj) {
+			return true
+		}
+	}
+
+	if uObj, ok := tobj.(MsgRevokeSession); ok {
+		matchedType = true
+		if f.MsgRevokeSession != nil && f.MsgRevokeSession.Eval(&uObj) {
+			return true
+		}
+	}
+	if uObj, ok := tobj.(*MsgRevokeSession); ok {
+		matchedType = true
+		if f.MsgRevokeSession != nil && f.MsgRevokeSession.Eval(uObj) {
+			return true
+		}
+	}
+
+	if uObj, ok := tobj.(MsgRevokeAllSessions); ok {
+		matchedType = true
+		if f.MsgRevokeAllSessions != nil && f.MsgRevokeAllSessions.Eval(&uObj) {
+			return true
+		}
+	}
+	if uObj, ok := tobj.(*MsgRevokeAllSessions); ok {
+		matchedType = true
+		if f.MsgRevokeAllSessions != nil && f.MsgRevokeAllSessions.Eval(uObj) {
 			return true
 		}
 	}
@@ -1355,6 +1611,21 @@ func (f *FilterTransaction) Eval(obj *Transaction) bool {
 		return false
 	}
 
+	// Handle Signatures slice
+	if f.Signatures != nil {
+		elemMatchSignatures := false
+		for _, elem := range obj.Signatures() {
+			if f.Signatures.Eval(elem) {
+				elemMatchSignatures = true
+			}
+		}
+
+		if !elemMatchSignatures {
+			return false
+		}
+
+	}
+
 	// Handle Response field
 	toEvalResponse := obj.Response()
 	if f.Response != nil && !f.Response.Eval(toEvalResponse) {
@@ -1645,6 +1916,58 @@ func (f *FilterStorageDepositEvent) Eval(obj *StorageDepositEvent) bool {
 	return true
 }
 
+func (f *FilterSignature) Eval(obj *Signature) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle Signature field
+	toEvalSignature := obj.Signature
+	if f.Signature != nil && !f.Signature.Eval(&toEvalSignature) {
+		return false
+	}
+
+	// Handle SessionAddr field
+	toEvalSessionAddr := obj.SessionAddr
+	if f.SessionAddr != nil && !f.SessionAddr.Eval(&toEvalSessionAddr) {
+		return false
+	}
+
+	// Handle PubKey field
+	toEvalPubKey := obj.PubKey
+	if f.PubKey != nil && !f.PubKey.Eval(&toEvalPubKey) {
+		return false
+	}
+
+	return true
+}
+
 func (f *FilterMsgRun) Eval(obj *MsgRun) bool {
 	// Evaluate logical operators first
 	if len(f.And) > 0 {
@@ -1698,6 +2021,171 @@ func (f *FilterMsgRun) Eval(obj *MsgRun) bool {
 	toEvalCaller := obj.Caller
 	if f.Caller != nil && !f.Caller.Eval(&toEvalCaller) {
 		return false
+	}
+
+	return true
+}
+
+func (f *FilterMsgRevokeSession) Eval(obj *MsgRevokeSession) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle SessionKey field
+	toEvalSessionKey := obj.SessionKey
+	if f.SessionKey != nil && !f.SessionKey.Eval(&toEvalSessionKey) {
+		return false
+	}
+
+	// Handle Creator field
+	toEvalCreator := obj.Creator
+	if f.Creator != nil && !f.Creator.Eval(&toEvalCreator) {
+		return false
+	}
+
+	return true
+}
+
+func (f *FilterMsgRevokeAllSessions) Eval(obj *MsgRevokeAllSessions) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle Creator field
+	toEvalCreator := obj.Creator
+	if f.Creator != nil && !f.Creator.Eval(&toEvalCreator) {
+		return false
+	}
+
+	return true
+}
+
+func (f *FilterMsgCreateSession) Eval(obj *MsgCreateSession) bool {
+	// Evaluate logical operators first
+	if len(f.And) > 0 {
+		for _, subFilter := range f.And {
+			if !subFilter.Eval(obj) {
+				return false
+			}
+		}
+	}
+
+	if len(f.Or) > 0 {
+		orResult := false
+		for _, subFilter := range f.Or {
+			if subFilter.Eval(obj) {
+				orResult = true
+				break
+			}
+		}
+		if !orResult {
+			return false
+		}
+	}
+
+	if f.Not != nil {
+		if f.Not.Eval(obj) {
+			return false
+		}
+	}
+
+	// Evaluate individual field filters
+
+	// Handle SpendPeriod field
+	toEvalSpendPeriod := toIntPtr(obj.SpendPeriod)
+	if f.SpendPeriod != nil && !f.SpendPeriod.Eval(toEvalSpendPeriod) {
+		return false
+	}
+
+	// Handle SpendLimit field
+	toEvalSpendLimit := obj.SpendLimit
+	if f.SpendLimit != nil && !f.SpendLimit.Eval(&toEvalSpendLimit) {
+		return false
+	}
+
+	// Handle SessionKey field
+	toEvalSessionKey := obj.SessionKey
+	if f.SessionKey != nil && !f.SessionKey.Eval(&toEvalSessionKey) {
+		return false
+	}
+
+	// Handle ExpiresAt field
+	toEvalExpiresAt := toIntPtr(obj.ExpiresAt)
+	if f.ExpiresAt != nil && !f.ExpiresAt.Eval(toEvalExpiresAt) {
+		return false
+	}
+
+	// Handle Creator field
+	toEvalCreator := obj.Creator
+	if f.Creator != nil && !f.Creator.Eval(&toEvalCreator) {
+		return false
+	}
+
+	// Handle AllowPaths slice
+	if f.AllowPaths != nil {
+		elemMatchAllowPaths := false
+		for _, elem := range obj.AllowPaths {
+			if f.AllowPaths.Eval(&elem) {
+				elemMatchAllowPaths = true
+			}
+		}
+
+		if !elemMatchAllowPaths {
+			return false
+		}
+
 	}
 
 	return true
@@ -1878,7 +2366,7 @@ func (f *FilterMessageValue) Eval(obj *MessageValue) bool {
 	// Handle union objects depending of the type
 
 	// Check if any filters are specified
-	filtersSpecified := f.BankMsgSend != nil || f.MsgCall != nil || f.MsgAddPackage != nil || f.MsgRun != nil || false
+	filtersSpecified := f.BankMsgSend != nil || f.MsgCall != nil || f.MsgAddPackage != nil || f.MsgRun != nil || f.MsgCreateSession != nil || f.MsgRevokeSession != nil || f.MsgRevokeAllSessions != nil || false
 
 	// If no filters are specified for any types, accept all objects
 	if !filtersSpecified {
@@ -1937,6 +2425,45 @@ func (f *FilterMessageValue) Eval(obj *MessageValue) bool {
 	if uObj, ok := tobj.(*MsgRun); ok {
 		matchedType = true
 		if f.MsgRun != nil && f.MsgRun.Eval(uObj) {
+			return true
+		}
+	}
+
+	if uObj, ok := tobj.(MsgCreateSession); ok {
+		matchedType = true
+		if f.MsgCreateSession != nil && f.MsgCreateSession.Eval(&uObj) {
+			return true
+		}
+	}
+	if uObj, ok := tobj.(*MsgCreateSession); ok {
+		matchedType = true
+		if f.MsgCreateSession != nil && f.MsgCreateSession.Eval(uObj) {
+			return true
+		}
+	}
+
+	if uObj, ok := tobj.(MsgRevokeSession); ok {
+		matchedType = true
+		if f.MsgRevokeSession != nil && f.MsgRevokeSession.Eval(&uObj) {
+			return true
+		}
+	}
+	if uObj, ok := tobj.(*MsgRevokeSession); ok {
+		matchedType = true
+		if f.MsgRevokeSession != nil && f.MsgRevokeSession.Eval(uObj) {
+			return true
+		}
+	}
+
+	if uObj, ok := tobj.(MsgRevokeAllSessions); ok {
+		matchedType = true
+		if f.MsgRevokeAllSessions != nil && f.MsgRevokeAllSessions.Eval(&uObj) {
+			return true
+		}
+	}
+	if uObj, ok := tobj.(*MsgRevokeAllSessions); ok {
+		matchedType = true
+		if f.MsgRevokeAllSessions != nil && f.MsgRevokeAllSessions.Eval(uObj) {
 			return true
 		}
 	}

--- a/serve/graph/model/models_gen.go
+++ b/serve/graph/model/models_gen.go
@@ -330,6 +330,12 @@ type FilterMessageValue struct {
 	MsgAddPackage *NestedFilterMsgAddPackage `json:"MsgAddPackage,omitempty"`
 	// filter for MsgRun union type.
 	MsgRun *NestedFilterMsgRun `json:"MsgRun,omitempty"`
+	// filter for MsgCreateSession union type.
+	MsgCreateSession *NestedFilterMsgCreateSession `json:"MsgCreateSession,omitempty"`
+	// filter for MsgRevokeSession union type.
+	MsgRevokeSession *NestedFilterMsgRevokeSession `json:"MsgRevokeSession,omitempty"`
+	// filter for MsgRevokeAllSessions union type.
+	MsgRevokeAllSessions *NestedFilterMsgRevokeAllSessions `json:"MsgRevokeAllSessions,omitempty"`
 }
 
 // filter for MsgAddPackage objects
@@ -374,6 +380,54 @@ type FilterMsgCall struct {
 	MaxDeposit *FilterString `json:"max_deposit,omitempty"`
 }
 
+// filter for MsgCreateSession objects
+type FilterMsgCreateSession struct {
+	// logical operator for MsgCreateSession that will combine two or more conditions, returning true if all of them are true.
+	And []*FilterMsgCreateSession `json:"_and,omitempty"`
+	// logical operator for MsgCreateSession that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*FilterMsgCreateSession `json:"_or,omitempty"`
+	// logical operator for MsgCreateSession that will reverse conditions.
+	Not *FilterMsgCreateSession `json:"_not,omitempty"`
+	// filter for creator field.
+	Creator *FilterString `json:"creator,omitempty"`
+	// filter for session_key field.
+	SessionKey *FilterString `json:"session_key,omitempty"`
+	// filter for expires_at field.
+	ExpiresAt *FilterInt `json:"expires_at,omitempty"`
+	// filter for allow_paths field.
+	AllowPaths *FilterString `json:"allow_paths,omitempty"`
+	// filter for spend_limit field.
+	SpendLimit *FilterString `json:"spend_limit,omitempty"`
+	// filter for spend_period field.
+	SpendPeriod *FilterInt `json:"spend_period,omitempty"`
+}
+
+// filter for MsgRevokeAllSessions objects
+type FilterMsgRevokeAllSessions struct {
+	// logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if all of them are true.
+	And []*FilterMsgRevokeAllSessions `json:"_and,omitempty"`
+	// logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*FilterMsgRevokeAllSessions `json:"_or,omitempty"`
+	// logical operator for MsgRevokeAllSessions that will reverse conditions.
+	Not *FilterMsgRevokeAllSessions `json:"_not,omitempty"`
+	// filter for creator field.
+	Creator *FilterString `json:"creator,omitempty"`
+}
+
+// filter for MsgRevokeSession objects
+type FilterMsgRevokeSession struct {
+	// logical operator for MsgRevokeSession that will combine two or more conditions, returning true if all of them are true.
+	And []*FilterMsgRevokeSession `json:"_and,omitempty"`
+	// logical operator for MsgRevokeSession that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*FilterMsgRevokeSession `json:"_or,omitempty"`
+	// logical operator for MsgRevokeSession that will reverse conditions.
+	Not *FilterMsgRevokeSession `json:"_not,omitempty"`
+	// filter for creator field.
+	Creator *FilterString `json:"creator,omitempty"`
+	// filter for session_key field.
+	SessionKey *FilterString `json:"session_key,omitempty"`
+}
+
 // filter for MsgRun objects
 type FilterMsgRun struct {
 	// logical operator for MsgRun that will combine two or more conditions, returning true if all of them are true.
@@ -390,6 +444,22 @@ type FilterMsgRun struct {
 	Package *NestedFilterMemPackage `json:"package,omitempty"`
 	// filter for max_deposit field.
 	MaxDeposit *FilterString `json:"max_deposit,omitempty"`
+}
+
+// filter for Signature objects
+type FilterSignature struct {
+	// logical operator for Signature that will combine two or more conditions, returning true if all of them are true.
+	And []*FilterSignature `json:"_and,omitempty"`
+	// logical operator for Signature that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*FilterSignature `json:"_or,omitempty"`
+	// logical operator for Signature that will reverse conditions.
+	Not *FilterSignature `json:"_not,omitempty"`
+	// filter for pub_key field.
+	PubKey *FilterString `json:"pub_key,omitempty"`
+	// filter for signature field.
+	Signature *FilterString `json:"signature,omitempty"`
+	// filter for session_addr field.
+	SessionAddr *FilterString `json:"session_addr,omitempty"`
 }
 
 // filter for StorageDepositEvent objects
@@ -478,6 +548,8 @@ type FilterTransaction struct {
 	Memo *FilterString `json:"memo,omitempty"`
 	// filter for response field.
 	Response *NestedFilterTransactionResponse `json:"response,omitempty"`
+	// filter for signatures field.
+	Signatures *NestedFilterSignature `json:"signatures,omitempty"`
 }
 
 // filter for TransactionMessage objects
@@ -689,6 +761,88 @@ type MsgCallInput struct {
 	Args []string `json:"args,omitempty"`
 }
 
+// `MsgCreateSession` is a message with a message router of `auth` and a message type of `create_session`.
+// `MsgCreateSession` creates a new session key on the creator's account for delegated signing.
+type MsgCreateSession struct {
+	// the bech32 address of the account owner that creates the session.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	Creator string `json:"creator"`
+	// the bech32 address derived from the session public key.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	SessionKey string `json:"session_key"`
+	// the unix timestamp (in seconds) at which the session expires.
+	// `0` means the session never expires until revoked.
+	ExpiresAt int `json:"expires_at"`
+	// the realm path entries the session is allowed to access.
+	// An empty list means the session is unrestricted.
+	AllowPaths []string `json:"allow_paths,omitempty"`
+	// the maximum amount of funds the session may spend per period ("<amount><denomination>").
+	// An empty value means the session may not spend any funds.
+	// ex) `1000000ugnot`
+	SpendLimit string `json:"spend_limit"`
+	// the spending period in seconds. `0` means `spend_limit` is a lifetime cap.
+	SpendPeriod int `json:"spend_period"`
+}
+
+func (MsgCreateSession) IsMessageValue() {}
+
+// `MsgCreateSessionInput` represents input parameters required when the message type is `create_session`.
+type MsgCreateSessionInput struct {
+	// the bech32 address of the account owner that creates the session.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	Creator *string `json:"creator,omitempty"`
+	// the bech32 address derived from the session public key.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	SessionKey *string `json:"session_key,omitempty"`
+	// the realm path entries the session is allowed to access.
+	// The entries are checked in order and empty strings are excluded from the
+	// filtering criteria.
+	// ex) `["", "", "gno.land/r/demo/foo"]` <- Empty strings skip the condition.
+	AllowPaths []string `json:"allow_paths,omitempty"`
+	// the maximum amount of funds the session may spend per period.
+	SpendLimit *AmountInput `json:"spend_limit,omitempty"`
+}
+
+// `MsgRevokeAllSessions` is a message with a message router of `auth` and a message type of `revoke_all_sessions`.
+// `MsgRevokeAllSessions` revokes all session keys from the creator's account.
+type MsgRevokeAllSessions struct {
+	// the bech32 address of the account owner that revokes all sessions.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	Creator string `json:"creator"`
+}
+
+func (MsgRevokeAllSessions) IsMessageValue() {}
+
+// `MsgRevokeAllSessionsInput` represents input parameters required when the message type is `revoke_all_sessions`.
+type MsgRevokeAllSessionsInput struct {
+	// the bech32 address of the account owner that revokes all sessions.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	Creator *string `json:"creator,omitempty"`
+}
+
+// `MsgRevokeSession` is a message with a message router of `auth` and a message type of `revoke_session`.
+// `MsgRevokeSession` revokes a specific session key from the creator's account.
+type MsgRevokeSession struct {
+	// the bech32 address of the account owner that revokes the session.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	Creator string `json:"creator"`
+	// the bech32 address derived from the session public key being revoked.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	SessionKey string `json:"session_key"`
+}
+
+func (MsgRevokeSession) IsMessageValue() {}
+
+// `MsgRevokeSessionInput` represents input parameters required when the message type is `revoke_session`.
+type MsgRevokeSessionInput struct {
+	// the bech32 address of the account owner that revokes the session.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	Creator *string `json:"creator,omitempty"`
+	// the bech32 address derived from the session public key being revoked.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	SessionKey *string `json:"session_key,omitempty"`
+}
+
 // `MsgRun` is a message with a message router of `vm` and a message type of `run`.
 // `MsgRun is the execute arbitrary Gno code tx message`.
 type MsgRun struct {
@@ -860,6 +1014,12 @@ type NestedFilterMessageValue struct {
 	MsgAddPackage *NestedFilterMsgAddPackage `json:"MsgAddPackage,omitempty"`
 	// filter for MsgRun union type.
 	MsgRun *NestedFilterMsgRun `json:"MsgRun,omitempty"`
+	// filter for MsgCreateSession union type.
+	MsgCreateSession *NestedFilterMsgCreateSession `json:"MsgCreateSession,omitempty"`
+	// filter for MsgRevokeSession union type.
+	MsgRevokeSession *NestedFilterMsgRevokeSession `json:"MsgRevokeSession,omitempty"`
+	// filter for MsgRevokeAllSessions union type.
+	MsgRevokeAllSessions *NestedFilterMsgRevokeAllSessions `json:"MsgRevokeAllSessions,omitempty"`
 }
 
 // filter for MsgAddPackage objects
@@ -904,6 +1064,54 @@ type NestedFilterMsgCall struct {
 	MaxDeposit *FilterString `json:"max_deposit,omitempty"`
 }
 
+// filter for MsgCreateSession objects
+type NestedFilterMsgCreateSession struct {
+	// logical operator for MsgCreateSession that will combine two or more conditions, returning true if all of them are true.
+	And []*NestedFilterMsgCreateSession `json:"_and,omitempty"`
+	// logical operator for MsgCreateSession that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*NestedFilterMsgCreateSession `json:"_or,omitempty"`
+	// logical operator for MsgCreateSession that will reverse conditions.
+	Not *NestedFilterMsgCreateSession `json:"_not,omitempty"`
+	// filter for creator field.
+	Creator *FilterString `json:"creator,omitempty"`
+	// filter for session_key field.
+	SessionKey *FilterString `json:"session_key,omitempty"`
+	// filter for expires_at field.
+	ExpiresAt *FilterInt `json:"expires_at,omitempty"`
+	// filter for allow_paths field.
+	AllowPaths *FilterString `json:"allow_paths,omitempty"`
+	// filter for spend_limit field.
+	SpendLimit *FilterString `json:"spend_limit,omitempty"`
+	// filter for spend_period field.
+	SpendPeriod *FilterInt `json:"spend_period,omitempty"`
+}
+
+// filter for MsgRevokeAllSessions objects
+type NestedFilterMsgRevokeAllSessions struct {
+	// logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if all of them are true.
+	And []*NestedFilterMsgRevokeAllSessions `json:"_and,omitempty"`
+	// logical operator for MsgRevokeAllSessions that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*NestedFilterMsgRevokeAllSessions `json:"_or,omitempty"`
+	// logical operator for MsgRevokeAllSessions that will reverse conditions.
+	Not *NestedFilterMsgRevokeAllSessions `json:"_not,omitempty"`
+	// filter for creator field.
+	Creator *FilterString `json:"creator,omitempty"`
+}
+
+// filter for MsgRevokeSession objects
+type NestedFilterMsgRevokeSession struct {
+	// logical operator for MsgRevokeSession that will combine two or more conditions, returning true if all of them are true.
+	And []*NestedFilterMsgRevokeSession `json:"_and,omitempty"`
+	// logical operator for MsgRevokeSession that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*NestedFilterMsgRevokeSession `json:"_or,omitempty"`
+	// logical operator for MsgRevokeSession that will reverse conditions.
+	Not *NestedFilterMsgRevokeSession `json:"_not,omitempty"`
+	// filter for creator field.
+	Creator *FilterString `json:"creator,omitempty"`
+	// filter for session_key field.
+	SessionKey *FilterString `json:"session_key,omitempty"`
+}
+
 // filter for MsgRun objects
 type NestedFilterMsgRun struct {
 	// logical operator for MsgRun that will combine two or more conditions, returning true if all of them are true.
@@ -920,6 +1128,22 @@ type NestedFilterMsgRun struct {
 	Package *NestedFilterMemPackage `json:"package,omitempty"`
 	// filter for max_deposit field.
 	MaxDeposit *FilterString `json:"max_deposit,omitempty"`
+}
+
+// filter for Signature objects
+type NestedFilterSignature struct {
+	// logical operator for Signature that will combine two or more conditions, returning true if all of them are true.
+	And []*NestedFilterSignature `json:"_and,omitempty"`
+	// logical operator for Signature that will combine two or more conditions, returning true if at least one of them is true.
+	Or []*NestedFilterSignature `json:"_or,omitempty"`
+	// logical operator for Signature that will reverse conditions.
+	Not *NestedFilterSignature `json:"_not,omitempty"`
+	// filter for pub_key field.
+	PubKey *FilterString `json:"pub_key,omitempty"`
+	// filter for signature field.
+	Signature *FilterString `json:"signature,omitempty"`
+	// filter for session_addr field.
+	SessionAddr *FilterString `json:"session_addr,omitempty"`
 }
 
 // filter for StorageDepositEvent objects
@@ -1024,6 +1248,30 @@ type NestedFilterUnknownEvent struct {
 type Query struct {
 }
 
+// `Signature` is a wrapped signature that signed a transaction.
+type Signature struct {
+	// the bech32 address of the signer derived from the public key.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	PubKey string `json:"pub_key"`
+	// the signature bytes in base64 encoding.
+	Signature string `json:"signature"`
+	// the bech32 address of the session account used for delegated signing.
+	// It is empty for master-key signatures.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	SessionAddr string `json:"session_addr"`
+}
+
+// Transaction's signature to filter transactions.
+// `SignatureInput` can be configured as a filter with a signature's `pub_key` or `session_addr`.
+type SignatureInput struct {
+	// the bech32 address of the signer derived from the public key.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	PubKey *string `json:"pub_key,omitempty"`
+	// the bech32 address of the session account used for delegated signing.
+	// ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+	SessionAddr *string `json:"session_addr,omitempty"`
+}
+
 // `StorageDepositEvent` is emitted when a storage deposit fee is locked.
 // It has `type`, `bytes_delta`, `fee_delta`, and `pkg_path`.
 type StorageDepositEvent struct {
@@ -1085,6 +1333,16 @@ type StorageUnlockEventInput struct {
 type Subscription struct {
 }
 
+// `TransactionAuthMessageInput` represents input parameters required when the message router is `auth`.
+type TransactionAuthMessageInput struct {
+	// `MsgCreateSessionInput` represents input parameters required when the message type is `create_session`.
+	CreateSession *MsgCreateSessionInput `json:"create_session,omitempty"`
+	// `MsgRevokeSessionInput` represents input parameters required when the message type is `revoke_session`.
+	RevokeSession *MsgRevokeSessionInput `json:"revoke_session,omitempty"`
+	// `MsgRevokeAllSessionsInput` represents input parameters required when the message type is `revoke_all_sessions`.
+	RevokeAllSessions *MsgRevokeAllSessionsInput `json:"revoke_all_sessions,omitempty"`
+}
+
 // `TransactionBankMessageInput` represents input parameters required when the message router is `bank`.
 type TransactionBankMessageInput struct {
 	// send represents input parameters required when the message type is `send`.
@@ -1128,6 +1386,11 @@ type TransactionFilter struct {
 	// `events` is entered as an array and works exclusively.
 	// ex) `events[0] || events[1] || events[2]`
 	Events []*EventInput `json:"events,omitempty"`
+	// `signatures` are the signatures that signed the transaction.
+	// `signatures` can be filtered with a specific signer, signature, or session address.
+	// `signatures` is entered as an array and works exclusively.
+	// ex) `signatures[0] || signatures[1] || signatures[2]`
+	Signatures []*SignatureInput `json:"signatures,omitempty"`
 }
 
 // Transaction's message to filter Transactions.
@@ -1143,6 +1406,8 @@ type TransactionMessageInput struct {
 	BankParam *TransactionBankMessageInput `json:"bank_param,omitempty"`
 	// `TransactionVmMessageInput` represents input parameters required when the message router is `vm`.
 	VMParam *TransactionVMMessageInput `json:"vm_param,omitempty"`
+	// `TransactionAuthMessageInput` represents input parameters required when the message router is `auth`.
+	AuthParam *TransactionAuthMessageInput `json:"auth_param,omitempty"`
 }
 
 type TransactionOrder struct {
@@ -1239,22 +1504,24 @@ func (e FilterableExtra) MarshalJSON() ([]byte, error) {
 }
 
 // `MessageRoute` is route type of the transactional message.
-// `MessageRoute` has the values of vm and bank.
+// `MessageRoute` has the values of vm, bank and auth.
 type MessageRoute string
 
 const (
 	MessageRouteVM   MessageRoute = "vm"
 	MessageRouteBank MessageRoute = "bank"
+	MessageRouteAuth MessageRoute = "auth"
 )
 
 var AllMessageRoute = []MessageRoute{
 	MessageRouteVM,
 	MessageRouteBank,
+	MessageRouteAuth,
 }
 
 func (e MessageRoute) IsValid() bool {
 	switch e {
-	case MessageRouteVM, MessageRouteBank:
+	case MessageRouteVM, MessageRouteBank, MessageRouteAuth:
 		return true
 	}
 	return false
@@ -1296,7 +1563,8 @@ func (e MessageRoute) MarshalJSON() ([]byte, error) {
 }
 
 // `MessageType` is message type of the transaction.
-// `MessageType` has the values `send`, `exec`, `add_package`, and `run`.
+// `MessageType` has the values `send`, `exec`, `add_package`, `run`,
+// `create_session`, `revoke_session`, and `revoke_all_sessions`.
 type MessageType string
 
 const (
@@ -1312,6 +1580,15 @@ const (
 	// The route value for this message type is `vm`, and the value for transactional messages is `MsgRun`.
 	// This is a transactional message that executes an arbitrary Gno-coded TX message.
 	MessageTypeRun MessageType = "run"
+	// The route value for this message type is `auth`, and the value for transactional messages is `MsgCreateSession`.
+	// This is a transactional message that creates a new session key on the creator's account.
+	MessageTypeCreateSession MessageType = "create_session"
+	// The route value for this message type is `auth`, and the value for transactional messages is `MsgRevokeSession`.
+	// This is a transactional message that revokes a specific session key from the creator's account.
+	MessageTypeRevokeSession MessageType = "revoke_session"
+	// The route value for this message type is `auth`, and the value for transactional messages is `MsgRevokeAllSessions`.
+	// This is a transactional message that revokes all session keys from the creator's account.
+	MessageTypeRevokeAllSessions MessageType = "revoke_all_sessions"
 )
 
 var AllMessageType = []MessageType{
@@ -1319,11 +1596,14 @@ var AllMessageType = []MessageType{
 	MessageTypeExec,
 	MessageTypeAddPackage,
 	MessageTypeRun,
+	MessageTypeCreateSession,
+	MessageTypeRevokeSession,
+	MessageTypeRevokeAllSessions,
 }
 
 func (e MessageType) IsValid() bool {
 	switch e {
-	case MessageTypeSend, MessageTypeExec, MessageTypeAddPackage, MessageTypeRun:
+	case MessageTypeSend, MessageTypeExec, MessageTypeAddPackage, MessageTypeRun, MessageTypeCreateSession, MessageTypeRevokeSession, MessageTypeRevokeAllSessions:
 		return true
 	}
 	return false

--- a/serve/graph/model/transaction.go
+++ b/serve/graph/model/transaction.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	abci "github.com/gnolang/gno/tm2/pkg/bft/abci/types"
 	"github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/sdk/auth"
 	"github.com/gnolang/gno/tm2/pkg/sdk/bank"
 	"github.com/gnolang/gno/tm2/pkg/std"
 )
@@ -78,6 +79,20 @@ func (t *Transaction) Memo() string {
 
 func (t *Transaction) Messages() []*TransactionMessage {
 	return t.getMessages()
+}
+
+func (t *Transaction) Signatures() []*Signature {
+	stdTx := t.getStdTx()
+	if stdTx == nil {
+		return nil
+	}
+
+	signatures := make([]*Signature, 0, len(stdTx.GetSignatures()))
+	for _, signature := range stdTx.GetSignatures() {
+		signatures = append(signatures, makeSignature(signature))
+	}
+
+	return signatures
 }
 
 func (t *Transaction) GasFee() *Coin {
@@ -233,6 +248,27 @@ func NewTransactionMessage(message std.Msg) *TransactionMessage {
 				Value:   makeVMMsgRun(message),
 			}
 		}
+	case auth.ModuleName:
+		switch message.Type() {
+		case MessageTypeCreateSession.String():
+			contentMessage = &TransactionMessage{
+				Route:   MessageRouteAuth.String(),
+				TypeURL: MessageTypeCreateSession.String(),
+				Value:   makeAuthMsgCreateSession(message),
+			}
+		case MessageTypeRevokeSession.String():
+			contentMessage = &TransactionMessage{
+				Route:   MessageRouteAuth.String(),
+				TypeURL: MessageTypeRevokeSession.String(),
+				Value:   makeAuthMsgRevokeSession(message),
+			}
+		case MessageTypeRevokeAllSessions.String():
+			contentMessage = &TransactionMessage{
+				Route:   MessageRouteAuth.String(),
+				TypeURL: MessageTypeRevokeAllSessions.String(),
+				Value:   makeAuthMsgRevokeAllSessions(message),
+			}
+		}
 	}
 
 	if contentMessage == nil {
@@ -260,6 +296,18 @@ func (tm *TransactionMessage) VMAddPackage() MsgAddPackage {
 
 func (tm *TransactionMessage) VMMsgRun() MsgRun {
 	return tm.Value.(MsgRun)
+}
+
+func (tm *TransactionMessage) AuthMsgCreateSession() MsgCreateSession {
+	return tm.Value.(MsgCreateSession)
+}
+
+func (tm *TransactionMessage) AuthMsgRevokeSession() MsgRevokeSession {
+	return tm.Value.(MsgRevokeSession)
+}
+
+func (tm *TransactionMessage) AuthMsgRevokeAllSessions() MsgRevokeAllSessions {
+	return tm.Value.(MsgRevokeAllSessions)
 }
 
 func makeEvent(abciEvent abci.Event) (Event, error) {
@@ -383,6 +431,73 @@ func makeVMMsgRun(value std.Msg) MsgRun {
 			Path:  decodedMessage.Package.Path,
 			Files: memFiles,
 		},
+	}
+}
+
+func makeAuthMsgCreateSession(value std.Msg) MsgCreateSession {
+	decodedMessage, ok := value.(auth.MsgCreateSession)
+	if !ok {
+		return MsgCreateSession{}
+	}
+
+	sessionKey := ""
+	if decodedMessage.SessionKey != nil {
+		sessionKey = decodedMessage.SessionKey.Address().String()
+	}
+
+	return MsgCreateSession{
+		Creator:     decodedMessage.Creator.String(),
+		SessionKey:  sessionKey,
+		ExpiresAt:   int(decodedMessage.ExpiresAt),
+		AllowPaths:  decodedMessage.AllowPaths,
+		SpendLimit:  decodedMessage.SpendLimit.String(),
+		SpendPeriod: int(decodedMessage.SpendPeriod),
+	}
+}
+
+func makeAuthMsgRevokeSession(value std.Msg) MsgRevokeSession {
+	decodedMessage, ok := value.(auth.MsgRevokeSession)
+	if !ok {
+		return MsgRevokeSession{}
+	}
+
+	sessionKey := ""
+	if decodedMessage.SessionKey != nil {
+		sessionKey = decodedMessage.SessionKey.Address().String()
+	}
+
+	return MsgRevokeSession{
+		Creator:    decodedMessage.Creator.String(),
+		SessionKey: sessionKey,
+	}
+}
+
+func makeAuthMsgRevokeAllSessions(value std.Msg) MsgRevokeAllSessions {
+	decodedMessage, ok := value.(auth.MsgRevokeAllSessions)
+	if !ok {
+		return MsgRevokeAllSessions{}
+	}
+
+	return MsgRevokeAllSessions{
+		Creator: decodedMessage.Creator.String(),
+	}
+}
+
+func makeSignature(signature std.Signature) *Signature {
+	pubKey := ""
+	if signature.PubKey != nil {
+		pubKey = signature.PubKey.Address().String()
+	}
+
+	sessionAddr := ""
+	if !signature.SessionAddr.IsZero() {
+		sessionAddr = signature.SessionAddr.String()
+	}
+
+	return &Signature{
+		PubKey:      pubKey,
+		Signature:   base64.StdEncoding.EncodeToString(signature.Signature),
+		SessionAddr: sessionAddr,
 	}
 }
 

--- a/serve/graph/schema/filter/transaction_filter.graphql
+++ b/serve/graph/schema/filter/transaction_filter.graphql
@@ -75,6 +75,32 @@ input TransactionFilter {
   ex) `events[0] || events[1] || events[2]`
   """
   events: [EventInput!]
+
+  """
+  `signatures` are the signatures that signed the transaction.
+  `signatures` can be filtered with a specific signer, signature, or session address.
+  `signatures` is entered as an array and works exclusively.
+  ex) `signatures[0] || signatures[1] || signatures[2]`
+  """
+  signatures: [SignatureInput!]
+}
+
+"""
+Transaction's signature to filter transactions.
+`SignatureInput` can be configured as a filter with a signature's `pub_key` or `session_addr`.
+"""
+input SignatureInput {
+  """
+  the bech32 address of the signer derived from the public key.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  pub_key: String
+
+  """
+  the bech32 address of the session account used for delegated signing.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  session_addr: String
 }
 
 """
@@ -230,6 +256,11 @@ input TransactionMessageInput {
   `TransactionVmMessageInput` represents input parameters required when the message router is `vm`.
   """
   vm_param: TransactionVmMessageInput
+
+  """
+  `TransactionAuthMessageInput` represents input parameters required when the message router is `auth`.
+  """
+  auth_param: TransactionAuthMessageInput
 }
 
 """
@@ -367,6 +398,84 @@ input MsgRunInput {
   the package being executed.
   """
   package: MemPackageInput
+}
+
+"""
+`TransactionAuthMessageInput` represents input parameters required when the message router is `auth`.
+"""
+input TransactionAuthMessageInput {
+  """
+  `MsgCreateSessionInput` represents input parameters required when the message type is `create_session`.
+  """
+  create_session: MsgCreateSessionInput
+
+  """
+  `MsgRevokeSessionInput` represents input parameters required when the message type is `revoke_session`.
+  """
+  revoke_session: MsgRevokeSessionInput
+
+  """
+  `MsgRevokeAllSessionsInput` represents input parameters required when the message type is `revoke_all_sessions`.
+  """
+  revoke_all_sessions: MsgRevokeAllSessionsInput
+}
+
+"""
+`MsgCreateSessionInput` represents input parameters required when the message type is `create_session`.
+"""
+input MsgCreateSessionInput {
+  """
+  the bech32 address of the account owner that creates the session.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  creator: String
+
+  """
+  the bech32 address derived from the session public key.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  session_key: String
+
+  """
+  the realm path entries the session is allowed to access.
+  The entries are checked in order and empty strings are excluded from the
+  filtering criteria.
+  ex) `["", "", "gno.land/r/demo/foo"]` <- Empty strings skip the condition.
+  """
+  allow_paths: [String!]
+
+  """
+  the maximum amount of funds the session may spend per period.
+  """
+  spend_limit: AmountInput
+}
+
+"""
+`MsgRevokeSessionInput` represents input parameters required when the message type is `revoke_session`.
+"""
+input MsgRevokeSessionInput {
+  """
+  the bech32 address of the account owner that revokes the session.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  creator: String
+
+  """
+  the bech32 address derived from the session public key being revoked.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  session_key: String
+}
+
+"""
+`MsgRevokeAllSessionsInput` represents input parameters required when the message type is `revoke_all_sessions`.
+"""
+input MsgRevokeAllSessionsInput {
+  """
+  the bech32 address of the account owner that revokes all sessions.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  creator: String
 }
 
 """

--- a/serve/graph/schema/types/transaction.graphql
+++ b/serve/graph/schema/types/transaction.graphql
@@ -61,20 +61,30 @@ type Transaction {
   It has `log`, `info`, `error`, and `data`.
   """
   response: TransactionResponse! @filterable
+
+  """
+  `signatures` are the signatures that signed the transaction.
+  Each signature includes the signer's public key, the signature bytes, and
+  an optional `session_addr` identifying the session account used for
+  delegated signing (empty for master-key signatures).
+  """
+  signatures: [Signature!] @filterable
 }
 
 """
 `MessageRoute` is route type of the transactional message.
-`MessageRoute` has the values of vm and bank.
+`MessageRoute` has the values of vm, bank and auth.
 """
 enum MessageRoute {
   vm
   bank
+  auth
 }
 
 """
 `MessageType` is message type of the transaction.
-`MessageType` has the values `send`, `exec`, `add_package`, and `run`.
+`MessageType` has the values `send`, `exec`, `add_package`, `run`,
+`create_session`, `revoke_session`, and `revoke_all_sessions`.
 """
 enum MessageType {
   """
@@ -100,6 +110,24 @@ enum MessageType {
   This is a transactional message that executes an arbitrary Gno-coded TX message.
   """
   run
+
+  """
+  The route value for this message type is `auth`, and the value for transactional messages is `MsgCreateSession`.
+  This is a transactional message that creates a new session key on the creator's account.
+  """
+  create_session
+
+  """
+  The route value for this message type is `auth`, and the value for transactional messages is `MsgRevokeSession`.
+  This is a transactional message that revokes a specific session key from the creator's account.
+  """
+  revoke_session
+
+  """
+  The route value for this message type is `auth`, and the value for transactional messages is `MsgRevokeAllSessions`.
+  This is a transactional message that revokes all session keys from the creator's account.
+  """
+  revoke_all_sessions
 }
 
 type TransactionMessage {
@@ -117,12 +145,21 @@ type TransactionMessage {
 
   """
   MessageValue is the content of the transaction.
-  `value` can be of type `BankMsgSend`, `MsgCall`, `MsgAddPackage`, `MsgRun`, `UnexpectedMessage`.
+  `value` can be of type `BankMsgSend`, `MsgCall`, `MsgAddPackage`, `MsgRun`,
+  `MsgCreateSession`, `MsgRevokeSession`, `MsgRevokeAllSessions`, `UnexpectedMessage`.
   """
   value: MessageValue! @filterable
 }
 
-union MessageValue = BankMsgSend | MsgCall | MsgAddPackage | MsgRun | UnexpectedMessage
+union MessageValue =
+    BankMsgSend
+  | MsgCall
+  | MsgAddPackage
+  | MsgRun
+  | MsgCreateSession
+  | MsgRevokeSession
+  | MsgRevokeAllSessions
+  | UnexpectedMessage
 
 """
 `BankMsgSend` is a message with a message router of `bank` and a message type of `send`.
@@ -249,6 +286,101 @@ type MsgRun {
   ex) `1000000ugnot`
   """
   max_deposit: String! @filterable
+}
+
+"""
+`MsgCreateSession` is a message with a message router of `auth` and a message type of `create_session`.
+`MsgCreateSession` creates a new session key on the creator's account for delegated signing.
+"""
+type MsgCreateSession {
+  """
+  the bech32 address of the account owner that creates the session.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  creator: String! @filterable
+
+  """
+  the bech32 address derived from the session public key.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  session_key: String! @filterable
+
+  """
+  the unix timestamp (in seconds) at which the session expires.
+  `0` means the session never expires until revoked.
+  """
+  expires_at: Int! @filterable
+
+  """
+  the realm path entries the session is allowed to access.
+  An empty list means the session is unrestricted.
+  """
+  allow_paths: [String!] @filterable
+
+  """
+  the maximum amount of funds the session may spend per period ("<amount><denomination>").
+  An empty value means the session may not spend any funds.
+  ex) `1000000ugnot`
+  """
+  spend_limit: String! @filterable
+
+  """
+  the spending period in seconds. `0` means `spend_limit` is a lifetime cap.
+  """
+  spend_period: Int! @filterable
+}
+
+"""
+`MsgRevokeSession` is a message with a message router of `auth` and a message type of `revoke_session`.
+`MsgRevokeSession` revokes a specific session key from the creator's account.
+"""
+type MsgRevokeSession {
+  """
+  the bech32 address of the account owner that revokes the session.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  creator: String! @filterable
+
+  """
+  the bech32 address derived from the session public key being revoked.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  session_key: String! @filterable
+}
+
+"""
+`MsgRevokeAllSessions` is a message with a message router of `auth` and a message type of `revoke_all_sessions`.
+`MsgRevokeAllSessions` revokes all session keys from the creator's account.
+"""
+type MsgRevokeAllSessions {
+  """
+  the bech32 address of the account owner that revokes all sessions.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  creator: String! @filterable
+}
+
+"""
+`Signature` is a wrapped signature that signed a transaction.
+"""
+type Signature {
+  """
+  the bech32 address of the signer derived from the public key.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  pub_key: String! @filterable
+
+  """
+  the signature bytes in base64 encoding.
+  """
+  signature: String! @filterable
+
+  """
+  the bech32 address of the session account used for delegated signing.
+  It is empty for master-key signatures.
+  ex) `g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5`
+  """
+  session_addr: String! @filterable
 }
 
 """

--- a/serve/graph/transaction_filter.go
+++ b/serve/graph/transaction_filter.go
@@ -454,13 +454,15 @@ func filteredMessageOfMsgCreateSessionBy(
 		return false
 	}
 
-	if params.CreateSession.SpendLimit != nil && !filteredAmountBy(messageValue.SpendLimit, params.CreateSession.SpendLimit) {
+	if params.CreateSession.SpendLimit != nil &&
+		!filteredAmountBy(messageValue.SpendLimit, params.CreateSession.SpendLimit) {
 		return false
 	}
 
 	if params.CreateSession.AllowPaths != nil {
 		messagePaths := messageValue.AllowPaths
 		filterPaths := params.CreateSession.AllowPaths
+
 		for index, path := range filterPaths {
 			if path == "" {
 				continue

--- a/serve/graph/transaction_filter.go
+++ b/serve/graph/transaction_filter.go
@@ -35,6 +35,10 @@ func FilteredTransactionBy(tx *model.Transaction, filter model.TransactionFilter
 		return false
 	}
 
+	if !filteredTransactionBySignatures(tx, filter.Signatures) {
+		return false
+	}
+
 	return true
 }
 
@@ -234,7 +238,7 @@ func filteredTransactionMessageBy(
 		return false
 	}
 
-	if messageInput.BankParam == nil && messageInput.VMParam == nil {
+	if messageInput.BankParam == nil && messageInput.VMParam == nil && messageInput.AuthParam == nil {
 		return true
 	}
 
@@ -245,6 +249,10 @@ func filteredTransactionMessageBy(
 		}
 	case model.MessageRouteVM.String():
 		if messageInput.VMParam == nil {
+			return false
+		}
+	case model.MessageRouteAuth.String():
+		if messageInput.AuthParam == nil {
 			return false
 		}
 	default:
@@ -266,6 +274,18 @@ func filteredTransactionMessageBy(
 		}
 	case model.MessageTypeRun.String():
 		if !filteredMessageOfMsgRunBy(tm.VMMsgRun(), messageInput.VMParam) {
+			return false
+		}
+	case model.MessageTypeCreateSession.String():
+		if !filteredMessageOfMsgCreateSessionBy(tm.AuthMsgCreateSession(), messageInput.AuthParam) {
+			return false
+		}
+	case model.MessageTypeRevokeSession.String():
+		if !filteredMessageOfMsgRevokeSessionBy(tm.AuthMsgRevokeSession(), messageInput.AuthParam) {
+			return false
+		}
+	case model.MessageTypeRevokeAllSessions.String():
+		if !filteredMessageOfMsgRevokeAllSessionsBy(tm.AuthMsgRevokeAllSessions(), messageInput.AuthParam) {
 			return false
 		}
 	default:
@@ -411,6 +431,122 @@ func filteredMessageOfMsgRunBy(messageValue model.MsgRun, vmMessageInput *model.
 		if deref(params.Run.Package.Path) != messageValue.Package.Path {
 			return false
 		}
+	}
+
+	return true
+}
+
+// `filteredMessageOfMsgCreateSessionBy` checks the conditions of a message of type MsgCreateSession.
+func filteredMessageOfMsgCreateSessionBy(
+	messageValue model.MsgCreateSession,
+	authMessageInput *model.TransactionAuthMessageInput,
+) bool {
+	params := authMessageInput
+	if params == nil || params.CreateSession == nil {
+		return true
+	}
+
+	if params.CreateSession.Creator != nil && deref(params.CreateSession.Creator) != messageValue.Creator {
+		return false
+	}
+
+	if params.CreateSession.SessionKey != nil && deref(params.CreateSession.SessionKey) != messageValue.SessionKey {
+		return false
+	}
+
+	if params.CreateSession.SpendLimit != nil && !filteredAmountBy(messageValue.SpendLimit, params.CreateSession.SpendLimit) {
+		return false
+	}
+
+	if params.CreateSession.AllowPaths != nil {
+		messagePaths := messageValue.AllowPaths
+		filterPaths := params.CreateSession.AllowPaths
+		for index, path := range filterPaths {
+			if path == "" {
+				continue
+			}
+
+			if index >= len(messagePaths) || messagePaths[index] != path {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// `filteredMessageOfMsgRevokeSessionBy` checks the conditions of a message of type MsgRevokeSession.
+func filteredMessageOfMsgRevokeSessionBy(
+	messageValue model.MsgRevokeSession,
+	authMessageInput *model.TransactionAuthMessageInput,
+) bool {
+	params := authMessageInput
+	if params == nil || params.RevokeSession == nil {
+		return true
+	}
+
+	if params.RevokeSession.Creator != nil && deref(params.RevokeSession.Creator) != messageValue.Creator {
+		return false
+	}
+
+	if params.RevokeSession.SessionKey != nil && deref(params.RevokeSession.SessionKey) != messageValue.SessionKey {
+		return false
+	}
+
+	return true
+}
+
+// `filteredMessageOfMsgRevokeAllSessionsBy` checks the conditions of a message of type MsgRevokeAllSessions.
+func filteredMessageOfMsgRevokeAllSessionsBy(
+	messageValue model.MsgRevokeAllSessions,
+	authMessageInput *model.TransactionAuthMessageInput,
+) bool {
+	params := authMessageInput
+	if params == nil || params.RevokeAllSessions == nil {
+		return true
+	}
+
+	if params.RevokeAllSessions.Creator != nil && deref(params.RevokeAllSessions.Creator) != messageValue.Creator {
+		return false
+	}
+
+	return true
+}
+
+// `filteredTransactionBySignatures` checks the transaction's signatures.
+func filteredTransactionBySignatures(tx *model.Transaction, signatureInputs []*model.SignatureInput) bool {
+	if len(signatureInputs) == 0 {
+		return true
+	}
+
+	signatures := tx.Signatures()
+	if len(signatures) == 0 {
+		return false
+	}
+
+	for _, signature := range signatures {
+		for _, signatureInput := range signatureInputs {
+			if filteredSignatureBy(signature, signatureInput) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// `filteredSignatureBy` checks the conditions of a signature.
+func filteredSignatureBy(signature *model.Signature, signatureInput *model.SignatureInput) bool {
+	if signature == nil {
+		return false
+	}
+
+	if signatureInput.PubKey != nil && deref(signatureInput.PubKey) != signature.PubKey {
+		return false
+	}
+
+	if signatureInput.SessionAddr != nil && deref(signatureInput.SessionAddr) != signature.SessionAddr {
+		return false
 	}
 
 	return true

--- a/storage/pebble.go
+++ b/storage/pebble.go
@@ -27,6 +27,10 @@ const (
 	// keyGenesisBalances holds the genesis balance rows, unfolded
 	keyGenesisBalances = "/meta/genesis/balances"
 
+	// keyTxAuditHeight is the highest height up to which the tx-completeness
+	// audit has verified stored blocks. It lets the audit resume across
+	// restarts instead of re-scanning from the start every time.
+	keyTxAuditHeight = "/meta/txah"
 	// prefixKeyBlocks is the key for each block saved. They are stored by height
 	prefixKeyBlocks = "/data/blocks/"
 
@@ -139,6 +143,34 @@ func (s *Pebble) GetGenesisBalances() ([]gnoland.Balance, error) {
 	return decodeGenesisBalances(balances)
 }
 
+// GetTxAuditHeight returns the highest height the tx-completeness audit has
+// verified, or ErrNotFound if it has never run.
+func (s *Pebble) GetTxAuditHeight() (uint64, error) {
+	val, c, err := s.db.Get([]byte(keyTxAuditHeight))
+	if errors.Is(err, pebble.ErrNotFound) {
+		return 0, storageErrors.ErrNotFound
+	}
+
+	if err != nil {
+		return 0, err
+	}
+
+	defer c.Close()
+
+	_, height, err := decodeUint64Ascending(val)
+
+	return height, err
+}
+
+// SetTxAuditHeight records how far the tx-completeness audit has verified.
+func (s *Pebble) SetTxAuditHeight(height uint64) error {
+	var val []byte
+
+	val = encodeUint64Ascending(val, height)
+
+	return s.db.Set([]byte(keyTxAuditHeight), val, pebble.Sync)
+}
+
 // GetBlock fetches the specified block from storage, if any
 func (s *Pebble) GetBlock(blockNum uint64) (*types.Block, error) {
 	block, c, err := s.db.Get(keyBlock(blockNum))
@@ -230,6 +262,19 @@ func (s *Pebble) BlockIterator(fromBlockNum, toBlockNum uint64) (Iterator[*types
 	}
 
 	return &PebbleBlockIter{pebbleBaseBlockIter: pebbleBaseBlockIter{i: it, s: snap}}, nil
+}
+
+// BlockHeightIterator iterates over stored block heights, reading each height
+// from the key without decoding the (potentially large) block value. This is
+// far cheaper than BlockIterator for height-only scans (e.g. gap detection),
+// and robust to nil / corrupt values since the value is never touched.
+func (s *Pebble) BlockHeightIterator(fromBlockNum, toBlockNum uint64) (Iterator[uint64], error) {
+	it, snap, err := s.loadBlockIterator(fromBlockNum, toBlockNum)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PebbleBlockHeightIter{i: it, s: snap}, nil
 }
 
 func (s *Pebble) BlockReverseIterator(fromBlockNum, toBlockNum uint64) (Iterator[*types.Block], error) {
@@ -404,6 +449,51 @@ func (pi *PebbleReverseBlockIter) Next() bool {
 	}
 
 	return pi.i.Valid() && pi.i.Prev()
+}
+
+var _ Iterator[uint64] = &PebbleBlockHeightIter{}
+
+// PebbleBlockHeightIter iterates over block heights, decoding the height from
+// the key only (never the block value).
+type PebbleBlockHeightIter struct {
+	i    *pebble.Iterator
+	s    *pebble.Snapshot
+	init bool
+}
+
+func (pi *PebbleBlockHeightIter) Next() bool {
+	if !pi.init {
+		pi.init = true
+
+		return pi.i.First()
+	}
+
+	return pi.i.Valid() && pi.i.Next()
+}
+
+func (pi *PebbleBlockHeightIter) Value() (uint64, error) {
+	var buf []byte
+
+	// Strip the block key prefix, then decode the height
+	key, _, err := decodeUnsafeStringAscending(pi.i.Key(), buf)
+	if err != nil {
+		return 0, err
+	}
+
+	_, height, err := decodeUint64Ascending(key)
+	if err != nil {
+		return 0, err
+	}
+
+	return height, nil
+}
+
+func (pi *PebbleBlockHeightIter) Error() error {
+	return pi.i.Error()
+}
+
+func (pi *PebbleBlockHeightIter) Close() error {
+	return multierr.Append(pi.i.Close(), pi.s.Close())
 }
 
 type pebbleBaseTxIter struct {

--- a/storage/pebble_test.go
+++ b/storage/pebble_test.go
@@ -177,6 +177,48 @@ func TestStorage_Tx(t *testing.T) {
 	}
 }
 
+func TestStorage_BlockHeightIterator(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewPebble(t.TempDir())
+	require.NoError(t, err)
+
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+
+	// Store blocks at non-contiguous heights: 0, 1, 3, 7
+	heights := []int64{0, 1, 3, 7}
+
+	b := s.WriteBatch()
+	for _, h := range heights {
+		require.NoError(t, b.SetBlock(&types.Block{Header: types.Header{Height: h}}))
+	}
+
+	require.NoError(t, b.Commit())
+
+	it, err := s.BlockHeightIterator(0, 7)
+	require.NoError(t, err)
+
+	defer func() {
+		assert.NoError(t, it.Close())
+	}()
+
+	var got []uint64
+
+	for it.Next() {
+		h, err := it.Value()
+		require.NoError(t, err)
+
+		got = append(got, h)
+	}
+
+	require.NoError(t, it.Error())
+
+	// Heights are read straight from the keys, in ascending order
+	assert.Equal(t, []uint64{0, 1, 3, 7}, got)
+}
+
 func TestStorageIters(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

When a chunk cannot be fully fetched, the fetcher logs `error encountered during chunk fetch, refetching range` and re-queues the whole range. Two issues made that path hard to diagnose in production:

- The error log only carried the range, so a range that kept failing (e.g. `[786, 877]` on the gnoscan prd indexer) gave no hint about **which** height the RPC node could not serve.
- `refetchFailedRanges` spawned the worker without `retry` and `logger`. The refetch therefore ran with a zero-value `retryConfig` (no retries at all) and a no-op logger, so the per-attempt `retrying missing blocks` / `retrying missing tx results` warnings never appeared on refetch.

## Changes

- `fetch/fetch.go`
  - Add `missingHeights` to the chunk-fetch error log so operators can pinpoint the failing block(s).
  - Pass `f.retry` and `f.logger` to the worker spawned by `refetchFailedRanges`, matching the initial fetch path.

## Testing

- `go build ./...`
- `go test ./fetch/`